### PR TITLE
Projection/stage windows to hide when monitor drops out

### DIFF
--- a/Quelea/src/main/java/org/quelea/windows/main/DisplayStage.java
+++ b/Quelea/src/main/java/org/quelea/windows/main/DisplayStage.java
@@ -44,7 +44,7 @@ import org.quelea.utils.PlatformUtils;
  */
 public class DisplayStage extends Stage {
 
-    private static final Logger LOGGER = LoggerUtils.getLogger();
+    protected static final Logger LOGGER = LoggerUtils.getLogger();
     private static final Cursor BLANK_CURSOR;
     private final DisplayCanvas canvas;
     private final TestImage testImage;
@@ -109,30 +109,34 @@ public class DisplayStage extends Stage {
             addVLCListeners();
         }
     }
+        
+    protected void windowChanged() {
+        // do nothing on purpose
+    }
 
     private void addVLCListeners() {
         widthProperty().addListener(new ChangeListener<Number>() {
             @Override
             public void changed(ObservableValue<? extends Number> observable, Number oldValue, Number newValue) {
-                VLCWindow.INSTANCE.refreshPosition();
+                windowChanged();
             }
         });
         heightProperty().addListener(new ChangeListener<Number>() {
             @Override
             public void changed(ObservableValue<? extends Number> observable, Number oldValue, Number newValue) {
-                VLCWindow.INSTANCE.refreshPosition();
+                windowChanged();
             }
         });
         xProperty().addListener(new ChangeListener<Number>() {
             @Override
             public void changed(ObservableValue<? extends Number> observable, Number oldValue, Number newValue) {
-                VLCWindow.INSTANCE.refreshPosition();
+                windowChanged();
             }
         });
         yProperty().addListener(new ChangeListener<Number>() {
             @Override
             public void changed(ObservableValue<? extends Number> observable, Number oldValue, Number newValue) {
-                VLCWindow.INSTANCE.refreshPosition();
+                windowChanged();
             }
         });
     }

--- a/Quelea/src/main/java/org/quelea/windows/main/ProjectorWindow.java
+++ b/Quelea/src/main/java/org/quelea/windows/main/ProjectorWindow.java
@@ -1,0 +1,89 @@
+/* 
+ * This file is part of Quelea, free projection software for churches.
+ * 
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.quelea.windows.main;
+
+import java.util.logging.Level;
+import javafx.application.Platform;
+import javafx.collections.ObservableList;
+import javafx.geometry.Bounds;
+import javafx.stage.Screen;
+import org.quelea.services.utils.QueleaProperties;
+import org.quelea.services.utils.Utils;
+import org.quelea.windows.multimedia.VLCWindow;
+import org.quelea.services.utils.LoggerUtils;
+import java.util.logging.Logger;
+
+/**
+ *
+ * @author Fabian
+ */
+public class ProjectorWindow extends DisplayStage {
+    
+    public static ProjectorWindow create() {
+        final ObservableList<Screen> monitors = Screen.getScreens();
+        final int projectorScreen = QueleaProperties.get().getProjectorScreen();
+        ProjectorWindow window = null;
+        if (needsHidding()) {
+            LOGGER.log(Level.INFO, "Hiding projector display on monitor 0 (base 0!)");
+            window = new ProjectorWindow(Utils.getBoundsFromRect2D(monitors.get(0).getVisualBounds()), false);
+            window.hide();
+        } else if (QueleaProperties.get().isProjectorModeCoords()) {
+            LOGGER.log(Level.INFO, "Starting projector display: ", QueleaProperties.get().getProjectorCoords());
+            window = new ProjectorWindow(QueleaProperties.get().getProjectorCoords(), false);
+        } else {
+            LOGGER.log(Level.INFO, "Starting projector display on monitor {0} (base 0!)", projectorScreen);
+            window = new ProjectorWindow(Utils.getBoundsFromRect2D(monitors.get(projectorScreen).getBounds()), false);
+            window.setFullScreenAlwaysOnTop(true);
+        }
+        
+        return window;
+    }
+    
+    public ProjectorWindow(Bounds area, boolean stageView) {
+        super(area, stageView);
+    }
+    
+    public static boolean needsHidding() {
+        final ObservableList<Screen> monitors = Screen.getScreens();
+        final int projectorScreen = QueleaProperties.get().getProjectorScreen();
+        final int monitorNumber = monitors.size();
+        
+        final boolean windowNeedsHidding;
+        if (!QueleaProperties.get().isProjectorModeCoords() && (projectorScreen >= monitorNumber || projectorScreen < 0)) {
+            windowNeedsHidding = true;
+        } else {
+            windowNeedsHidding = false;
+        }
+        
+        return windowNeedsHidding;
+    }
+    
+    @Override
+    protected void windowChanged() {
+        
+        // this is here incase the projector monitor drops out
+        // which often happens at my church when another TV is plugged in or out
+        if (needsHidding()) {
+            hide();
+            VLCWindow.INSTANCE.hide();
+        }
+        else {
+            VLCWindow.INSTANCE.refreshPosition();
+        }
+    }
+}

--- a/Quelea/src/main/java/org/quelea/windows/main/QueleaApp.java
+++ b/Quelea/src/main/java/org/quelea/windows/main/QueleaApp.java
@@ -35,8 +35,8 @@ public class QueleaApp {
 
     private static final QueleaApp INSTANCE = new QueleaApp();
     private MainWindow mainWindow;
-    private DisplayStage projectionWindow;
-    private DisplayStage stageWindow;
+    private ProjectorWindow projectionWindow;
+    private StageWindow stageWindow;
     private MobileLyricsServer mls;
     private RemoteControlServer rcs;
     private AutoDetectServer ads;
@@ -85,7 +85,7 @@ public class QueleaApp {
      * Get the projection window.
      * @return the projection window.
      */
-    public DisplayStage getProjectionWindow() {
+    public ProjectorWindow getProjectionWindow() {
         return projectionWindow;
     }
 
@@ -93,7 +93,7 @@ public class QueleaApp {
      * Get the stage window.
      * @return the stage window.
      */
-    public DisplayStage getStageWindow() {
+    public StageWindow getStageWindow() {
         return stageWindow;
     }
 
@@ -150,7 +150,7 @@ public class QueleaApp {
      * Set the projection window.
      * @param projectionWindow the projection window.
      */
-    public void setProjectionWindow(DisplayStage projectionWindow) {
+    public void setProjectionWindow(ProjectorWindow projectionWindow) {
         this.projectionWindow = projectionWindow;
     }
 
@@ -158,7 +158,7 @@ public class QueleaApp {
      * Set the stage window.
      * @param lyricWindow the stage window.
      */
-    public void setStageWindow(DisplayStage lyricWindow) {
+    public void setStageWindow(StageWindow lyricWindow) {
         this.stageWindow = lyricWindow;
     }
 

--- a/Quelea/src/main/java/org/quelea/windows/main/StageWindow.java
+++ b/Quelea/src/main/java/org/quelea/windows/main/StageWindow.java
@@ -1,0 +1,80 @@
+/* 
+ * This file is part of Quelea, free projection software for churches.
+ * 
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.quelea.windows.main;
+
+import java.util.logging.Level;
+import javafx.collections.ObservableList;
+import javafx.geometry.Bounds;
+import javafx.stage.Screen;
+import org.quelea.services.utils.QueleaProperties;
+import org.quelea.services.utils.Utils;
+
+/**
+ *
+ * @author Fabian
+ */
+public class StageWindow extends DisplayStage {
+    
+    public static StageWindow create() {
+        final ObservableList<Screen> monitors = Screen.getScreens();
+        final int projectorScreen = QueleaProperties.get().getProjectorScreen();
+        StageWindow window = null;     
+        if (needsHidding()) {
+            LOGGER.log(Level.INFO, "Hiding stage display on monitor 0 (base 0!)");
+            window = new StageWindow(Utils.getBoundsFromRect2D(monitors.get(0).getVisualBounds()), true);
+            window.hide();
+        } else if (QueleaProperties.get().isStageModeCoords()) {
+            LOGGER.log(Level.INFO, "Starting stage display: ", QueleaProperties.get().getStageCoords());
+            window = new StageWindow(QueleaProperties.get().getStageCoords(), true);
+        } else {
+            final int stageScreen = QueleaProperties.get().getStageScreen();
+            LOGGER.log(Level.INFO, "Starting stage display on monitor {0} (base 0!)", stageScreen);
+            window = new StageWindow(Utils.getBoundsFromRect2D(monitors.get(stageScreen).getVisualBounds()), true);
+        }
+
+        return window;
+    }
+    public StageWindow(Bounds area, boolean stageView) {
+        super(area, stageView);
+    }
+    
+    public static boolean needsHidding() {
+        final ObservableList<Screen> monitors = Screen.getScreens();
+
+        final int stageScreen = QueleaProperties.get().getStageScreen();
+        final int monitorNumber = monitors.size();
+        
+        final boolean windowNeedsHidding;
+        if (!QueleaProperties.get().isStageModeCoords() && (stageScreen >= monitorNumber || stageScreen < 0)) {
+            windowNeedsHidding = true;
+        } else {
+            windowNeedsHidding = false;
+        }
+        
+        return windowNeedsHidding;
+    }
+    
+    @Override
+    protected void windowChanged() {
+        
+        // this is here incase the stage monitor drops out
+        if (needsHidding()) {
+            hide();
+        }
+    }
+}

--- a/Quelea/src/main/java/org/quelea/windows/options/OptionsDisplaySetupPanel.java
+++ b/Quelea/src/main/java/org/quelea/windows/options/OptionsDisplaySetupPanel.java
@@ -27,7 +27,9 @@ import org.quelea.services.utils.QueleaProperties;
 import org.quelea.windows.main.DisplayStage;
 import org.quelea.windows.main.GraphicsDeviceListener;
 import org.quelea.windows.main.GraphicsDeviceWatcher;
+import org.quelea.windows.main.ProjectorWindow;
 import org.quelea.windows.main.QueleaApp;
+import org.quelea.windows.main.StageWindow;
 import org.quelea.windows.multimedia.VLCWindow;
 
 /**
@@ -117,19 +119,19 @@ public class OptionsDisplaySetupPanel extends GridPane implements PropertyPanel 
      */
     private void updatePos() {
 //        MainWindow mainWindow = Application.get().getMainWindow();
-        DisplayStage appWindow = QueleaApp.get().getProjectionWindow();
-        DisplayStage stageWindow = QueleaApp.get().getStageWindow();
+        ProjectorWindow projectorWindow = QueleaApp.get().getProjectionWindow();
+        StageWindow stageWindow = QueleaApp.get().getStageWindow();
         if(projectorPanel.getOutputBounds() == null) {
-            if(appWindow != null) {
-                appWindow.setFullScreenAlwaysOnTopImmediate(false);
-                appWindow.hide();
+            if(projectorWindow != null) {
+                projectorWindow.setFullScreenAlwaysOnTopImmediate(false);
+                projectorWindow.hide();
             }
         }
         else {
-            if(appWindow == null) {
-                appWindow = new DisplayStage(projectorPanel.getOutputBounds(), false);
+            if(projectorWindow == null) {
+                projectorWindow = new ProjectorWindow(projectorPanel.getOutputBounds(), false);
             }
-            final DisplayStage fiLyricWindow = appWindow; //Fudge for AIC
+            final DisplayStage fiLyricWindow = projectorWindow; //Fudge for AIC
             Platform.runLater(new Runnable() {
                 @Override
                 public void run() {
@@ -152,7 +154,7 @@ public class OptionsDisplaySetupPanel extends GridPane implements PropertyPanel 
         }
         else {
             if(stageWindow == null) {
-                stageWindow = new DisplayStage(projectorPanel.getOutputBounds(), true);
+                stageWindow = new StageWindow(projectorPanel.getOutputBounds(), true);
             }
             final DisplayStage fiStageWindow = stageWindow; //Fudge for AIC
             Platform.runLater(new Runnable() {


### PR DESCRIPTION
I've split out the projection window and stage window into their own classes and moved the creation functionality there.

Now when a window is moved or resized, it does a monitor check and will hide it if the monitor it is meant to be assigned to is no longer available.

This fixes the situation where at our church we have a HDMI splitter, and everytime we plugin or unplug a TV/projector into it, the projection windows get forced back into the primary display and make the PC unusable as the second display momentarily drops out.

Now the above case will be detected, and hide the windows. The user may now recover by going back into the Tools > Options and hitting apply as per usual to reconfigure/position and show the windows when the display is restored.

