### PR TITLE
Openlyrics import verse name

### DIFF
--- a/Quelea/src/main/java/org/quelea/services/importexport/OpenLyricsParser.java
+++ b/Quelea/src/main/java/org/quelea/services/importexport/OpenLyricsParser.java
@@ -148,6 +148,9 @@ public class OpenLyricsParser implements SongParser {
             LOGGER.log(Level.WARNING, "Couldn't create openlyrics object");
         } else {
             for (Verse verse : ol.getVerses()) {
+                if (!verse.getName().isEmpty()) {
+                    ret.append(parseVerseName(verse.getName()));
+                }
                 for (VerseLine line : verse.getLines()) {
                     ret.append(line.getText().trim()).append('\n');
                 }
@@ -157,4 +160,37 @@ public class OpenLyricsParser implements SongParser {
         return ret.toString().trim();
     }
 
+    /**
+     * Parse verse name as a verse title string.
+     *
+     * @param verseName the openlyrics verse name
+     * @return the verse title as a string, or an empty string if the name could not be parsed
+     */
+    private String parseVerseName(String verseName)
+    {
+        String ret = "";
+        if (verseName.toLowerCase().startsWith("v")) {
+            // This is a verse, e.g. "v1".
+            if (verseName.length() > 1) {
+                ret = "Verse " + verseName.substring(1) + "\n";
+            } else {
+                ret = "Verse\n";
+            }
+        } else if (verseName.toLowerCase().startsWith("c")) {
+            // This is a chorus, e.g. "c1".
+            if (verseName.length() > 1) {
+                ret = "Chorus " + verseName.substring(1) + "\n";
+            } else {
+                ret = "Chorus\n";
+            }
+        } else if (verseName.toLowerCase().startsWith("b")) {
+            // This is a bridge, e.g. "b1".
+            if (verseName.length() > 1) {
+                ret = "Bridge " + verseName.substring(1) + "\n";
+            } else {
+                ret = "Bridge\n";
+            }
+        }
+        return ret;
+    }
 }

--- a/Quelea/src/main/java/org/quelea/services/importexport/OpenLyricsParser.java
+++ b/Quelea/src/main/java/org/quelea/services/importexport/OpenLyricsParser.java
@@ -161,10 +161,10 @@ public class OpenLyricsParser implements SongParser {
     }
 
     /**
-     * Parse verse name as a verse title string.
+     * Parse verse name as a section title string.
      *
      * @param verseName the openlyrics verse name
-     * @return the verse title as a string, or an empty string if the name could not be parsed
+     * @return the section title as a string, or an empty string if the name could not be parsed
      */
     private String parseVerseName(String verseName)
     {
@@ -189,6 +189,13 @@ public class OpenLyricsParser implements SongParser {
                 ret = "Bridge " + verseName.substring(1) + "\n";
             } else {
                 ret = "Bridge\n";
+            }
+        } else if (verseName.toLowerCase().startsWith("p")) {
+            // This is a pre-chorus, e.g. "p1".
+            if (verseName.length() > 1) {
+                ret = "Pre-chorus " + verseName.substring(1) + "\n";
+            } else {
+                ret = "Pre-chorus\n";
             }
         }
         return ret;


### PR DESCRIPTION
The openlyrics import does not import the name property of the verse attribute. The result is that the complete song is text only, without the Quelea section titles.
I think the name property could and should be mapped to the section titles. I created this and it helped us a lot with importing songs. Please comment on my proposal. I directly created a pull request, because I believe it is a small, low risk change.