### PR TITLE
Sync logo displaying state on setDisplayable

### DIFF
--- a/Quelea/src/main/java/org/quelea/windows/main/LivePanel.java
+++ b/Quelea/src/main/java/org/quelea/windows/main/LivePanel.java
@@ -473,6 +473,7 @@ public class LivePanel extends LivePreviewPanel {
         HashSet<DisplayCanvas> canvases = new HashSet<>();
         canvases.addAll(getCanvases());
         for (DisplayCanvas canvas : canvases) {
+            canvas.setLogoDisplaying(logo.isSelected());
             canvas.setBlacked(black.isSelected());
             if (canvas.isStageView() && !QueleaProperties.get().getClearStageWithMain()) {
                 canvas.setCleared(false);


### PR DESCRIPTION
I've noticed this bug a couple of times while running the projector:

1. Go live with song lyrics
2. Display the logo (F5)
3. Go live with a presentation
4. Hide the logo (F5)
5. Go live with song lyrics

In this situation, the projector screen displays the lyrics, as expected, but the preview canvas in the Live panel still shows the logo. I would expect both to display the lyrics, because the logo button is now disabled.

This change causes the canvas to be fully synced with all three of the override states (logo, black, and clear) whenever the displayable changes, and seems to resolve the issue!