### PR TITLE
Added a Setup Guide for new contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,8 @@ We're usually a little more cagey about accepting pull requests for new features
 
 Major refactorings of the project, or a significant part of it, are very unlikely to be accepted unless specifically discussed and agreed in advance. (This is usually something that we'd leave to the core developers though.)
 
+Please see the [Setup Guide](docs/SETUP.md) for information on setting up a local development environment.
+
 ## Final notes
 
 Please don't let any of the above put you off contributing! We love contributions, and we're always happy to work with you where we can. We just can't promise to accept everything - Quelea now has a reasonable user base and the decisions we make around the code have real world implications, so we have to be convinced that contributions are definitely going to have a positive effect on our users before we accept them.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,0 +1,24 @@
+# Setup Guide
+
+## Dependencies
+
+Quelea is built on [Java 1.8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) and [Gradle](https://gradle.org/); you will need those tools installed locally to compile the application.
+
+## Step-by-step
+
+If you're not familiar with working on Java desktop applications, you can follow these steps to get started contributing to Quelea using [IntelliJ IDEA](https://www.jetbrains.com/idea/). (IntelliJ IDEA is not required to work on Quelea; these are just steps for getting started if you're not already familiar with Java IDEs)
+
+1. Download and install the [Java SE Development Kit 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) for your platform.
+2. Download and install [Gradle](https://gradle.org/install/).
+3. Download and install [IntelliJ IDEA](https://www.jetbrains.com/idea/download) Community version for free.
+4. Fork the Quelea repository and git clone it locally.
+5. Open IntelliJ IDEA.
+6. Choose "Import Project" from the Welcome window.
+7. Navigate to the local Quelea repository and select the `Quelea/build.gradle` file.
+8. Check the box labelled "Use auto-import".
+9. Ensure that the selection for "Gradle JVM" has a "java version" that starts with `1.8`.
+10. Click OK to import the project.
+11. Navigate to the `src/main/java/org/quelea/windows/main/Main` class.
+12. Right-click on that class in the sidebar and click "Debug 'Main.main()'"
+
+If everything's gone smoothly, you should see Quelea launch. You're now ready to make and test changes!


### PR DESCRIPTION
I have a bit of a tricky time getting my local environment set up. Partly because I'm not familiar with Java desktop development, and also because it's not really documented anywhere that it requires JDK 8 (later versions don't include the `javafx` package). 

So I wrote up a quick guide both listed the bare minimum that I suspect a Java pro would need to know to get started as well as a step-by-step guide intended to help a developer less experienced with this particular stack install IntelliJ IDEA and get Quelea compiling and running.

Please let me know if I've explained anything incorrectly or if you'd prefer to recommend a tool other than IntelliJ!