### PR TITLE
Update old Quelea community google group link to the current one

### DIFF
--- a/Quelea/changelogs/changelog-2020.0.txt
+++ b/Quelea/changelogs/changelog-2020.0.txt
@@ -10,3 +10,4 @@ quelea (2020.0) stable
   * Fix importers to accept windows-encoded zip files
   * Fix export to PDF fonts issues (# instead of some characters)
   * Fix non-Latin and accented character input for song lyrics on Linux systems
+  * Update "Support / Discussion" link from the previous Quelea Google Group to the actual Quelea Community

--- a/Quelea/changelogs/changelog-2020.0.txt
+++ b/Quelea/changelogs/changelog-2020.0.txt
@@ -10,4 +10,4 @@ quelea (2020.0) stable
   * Fix importers to accept windows-encoded zip files
   * Fix export to PDF fonts issues (# instead of some characters)
   * Fix non-Latin and accented character input for song lyrics on Linux systems
-  * Update "Support / Discussion" link from the previous Quelea Google Group to the actual Quelea Community
+  * Update "Support / Discussion" link from the previous Quelea Google Group to the current Quelea Community

--- a/Quelea/src/main/java/org/quelea/services/utils/QueleaProperties.java
+++ b/Quelea/src/main/java/org/quelea/services/utils/QueleaProperties.java
@@ -1401,7 +1401,7 @@ public final class QueleaProperties extends Properties {
      * @return the URL to the Quelea discussion forum.
      */
     public String getDiscussLocation() {
-        return getProperty(discussLocationKey, "https://groups.google.com/group/quelea-discuss");
+        return getProperty(discussLocationKey, "https://quelea.discourse.group/");
     }
 
     /**


### PR DESCRIPTION
Addresses bug #204 

Updates the "Support / Discussion" link to the current Quelea Community. 

Let me know if something is wrong. Thanks!