### PR TITLE
Added capitalized versions of file extensions

### DIFF
--- a/Quelea/src/main/java/org/quelea/services/utils/Utils.java
+++ b/Quelea/src/main/java/org/quelea/services/utils/Utils.java
@@ -805,11 +805,17 @@ public final class Utils {
 	public static List<String> getImageExtensions() {
 		List<String> ret = new ArrayList<>();
 		ret.add("png");
+		ret.add("PNG");
 		ret.add("tiff");
+		ret.add("TIFF");
 		ret.add("jpg");
+		ret.add("JPG");
 		ret.add("jpeg");
+		ret.add("JPEG");
 		ret.add("gif");
+		ret.add("GIF");
 		ret.add("bmp");
+		ret.add("BMP");
 		return ret;
 	}
 
@@ -821,20 +827,35 @@ public final class Utils {
 	public static List<String> getVideoExtensions() {
 		List<String> ret = new ArrayList<>();
 		ret.add("mkv");
+		ret.add("MKV");
 		ret.add("mp4");
+		ret.add("MP4");
 		ret.add("m4v");
+		ret.add("M4V");
 		ret.add("flv");
+		ret.add("FLV");
 		ret.add("avi");
+		ret.add("AVI");
 		ret.add("mov");
+		ret.add("MOV");
 		ret.add("rm");
+		ret.add("RM");
 		ret.add("mpg");
+		ret.add("MPG");
 		ret.add("mpeg");
+		ret.add("MPEG");
 		ret.add("wmv");
+		ret.add("WMV");
 		ret.add("ogm");
+		ret.add("OGM");
 		ret.add("mrl");
+		ret.add("MRL");
 		ret.add("asx");
+		ret.add("ASX");
 		ret.add("m2ts");
+		ret.add("M2TS");
 		ret.add("vlcarg");
+		ret.add("VLCARG");
 		return ret;
 	}
 
@@ -846,8 +867,11 @@ public final class Utils {
 	public static List<String> getAudioExtensions() {
 		List<String> ret = new ArrayList<>();
 		ret.add("mp3");
+		ret.add("MP3");
 		ret.add("wav");
+		ret.add("WAV");
 		ret.add("wma");
+		ret.add("WMA");
 		// TODO: Add more extensions
 		return ret;
 	}


### PR DESCRIPTION
#217 
Added capitalized versions of file extensions for image, video, and audio files

----

I think it would be even better to use Regex instead of arrays to match extensions. This way, you can add a case insensitive flag, and match all case combinations. I don't know how to implement it, perhaps y'all do. But here are some expressions that can be used for matching those extensions:

Image:
`/\.(png|tiff|jp(e)?g|gif|bmp)$/i`
Video:
`/\.(mkv|mp4|m4v|flv|avi|mov|rm|mp(e)?g|wmv|ogm|mrl|asx|m2ts|vlcarg)$/i`
Audio:
`/\.(mp3|wav|wma)$/i`

You may also need to adapt these slightly for Java, but probably not much since these are valid JavaScript. Hopefully I didn't leave any out in the expressions here.