### PR TITLE
Fix #279 : Sort Properties File

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,18 +29,25 @@ before_install:
   - DISPLAY=:0.0 wine innosetup-5.6.1.exe /VERYSILENT /SUPPRESSMSGBOXES
 jdk:
   - oraclejdk9
-script:
-  - "./gradlew -Dnightly=true -Dversionsuffix=CI-UNSTABLE clean dist --scan"
-  - PREVDIR="$(pwd)"
-  - cd $(mktemp -d)
-  - git clone https://quelea-bot:${QBOT_TOKEN}@github.com/quelea-projection/quelea-projection.github.io.git ./repo
-  - cp $PREVDIR/dist/missinglabels.js repo/lang/
-  - cd repo
-  - ls -l lang/
-  - git add lang/missinglabels.js
-  - git commit -m "Update missing labels file" || ls -l
-  - if [ $TRAVIS_BRANCH == "master" ] && [ $TRAVIS_PULL_REQUEST == "false" ]; then git push; fi
-  - cd $PREVDIR
+jobs:
+  include:
+    - stage: build
+      script:
+        - "./gradlew -Dnightly=true -Dversionsuffix=CI-UNSTABLE clean dist --scan"
+        - PREVDIR="$(pwd)"
+        - cd $(mktemp -d)
+        - git clone https://quelea-bot:${QBOT_TOKEN}@github.com/quelea-projection/quelea-projection.github.io.git ./repo
+        - cp $PREVDIR/dist/missinglabels.js repo/lang/
+        - cd repo
+        - ls -l lang/
+        - git add lang/missinglabels.js
+        - git commit -m "Update missing labels file" || ls -l
+        - if [ $TRAVIS_BRANCH == "master" ] && [ $TRAVIS_PULL_REQUEST == "false" ]; then git push; fi
+        - cd $PREVDIR
+    - stage: test
+      script:
+        - "./gradlew clean test"
+        
 before_deploy:
   - git config --global user.email "builds@travis-ci.com"
   - git config --global user.name "Travis CI"

--- a/Quelea/build.gradle
+++ b/Quelea/build.gradle
@@ -231,7 +231,8 @@ dependencies {
 
     compile group: 'com.dlsc.preferencesfx', name: 'preferencesfx-core', version: '8.4.3'
 
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.0")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.0")
 }
 
 repositories {
@@ -252,4 +253,8 @@ jar {
 task releaseSummary(type:JavaExec) {
     main = 'org.quelea.services.utils.ReleaseSummaryGenerator'
     classpath = sourceSets.main.runtimeClasspath
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/Quelea/src/main/java/org/quelea/services/utils/QueleaProperties.java
+++ b/Quelea/src/main/java/org/quelea/services/utils/QueleaProperties.java
@@ -28,12 +28,12 @@ import java.util.logging.Level;
 import javafx.geometry.BoundingBox;
 import javafx.geometry.Bounds;
 import javafx.scene.paint.Color;
+import org.apache.commons.collections4.properties.SortedProperties;
 import org.quelea.data.bible.Bible;
 import org.quelea.data.displayable.TextAlignment;
 import org.quelea.services.languages.spelling.Dictionary;
 import org.quelea.services.languages.spelling.DictionaryManager;
 import org.quelea.services.notice.NoticeDrawer.NoticePosition;
-import org.apache.commons.collections4.properties.SortedProperties;
 
 import static org.quelea.services.utils.QueleaPropertyKeys.*;
 

--- a/Quelea/src/main/java/org/quelea/services/utils/QueleaProperties.java
+++ b/Quelea/src/main/java/org/quelea/services/utils/QueleaProperties.java
@@ -34,6 +34,7 @@ import org.quelea.data.displayable.TextAlignment;
 import org.quelea.services.languages.spelling.Dictionary;
 import org.quelea.services.languages.spelling.DictionaryManager;
 import org.quelea.services.notice.NoticeDrawer.NoticePosition;
+import org.apache.commons.collections4.properties.SortedProperties;
 
 import static org.quelea.services.utils.QueleaPropertyKeys.*;
 
@@ -43,7 +44,7 @@ import static org.quelea.services.utils.QueleaPropertyKeys.*;
  *
  * @author Michael
  */
-public final class QueleaProperties extends Properties {
+public final class QueleaProperties extends SortedProperties {
 
     public static final Version VERSION = new Version("2021.0", VersionType.CI);
     private static QueleaProperties INSTANCE;

--- a/Quelea/src/main/java/org/quelea/services/utils/QueleaProperties.java
+++ b/Quelea/src/main/java/org/quelea/services/utils/QueleaProperties.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Properties;
 import java.util.logging.Level;
 
 import javafx.geometry.BoundingBox;

--- a/Quelea/src/test/java/org/quelea/services/utils/QueleaPropertiesTest.java
+++ b/Quelea/src/test/java/org/quelea/services/utils/QueleaPropertiesTest.java
@@ -1,0 +1,39 @@
+package org.quelea.services.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.ArrayList;
+import java.util.Scanner;
+import java.util.Collections;
+
+public class QueleaPropertiesTest {
+
+    @Test
+    // check whether properties file is sorted
+    public void testIfPropertiesFileIsSorted() throws FileNotFoundException {
+        // init properties
+        QueleaProperties.init("");
+        // trigger a properties write
+        QueleaProperties.get().setCheckUpdate(true);
+        // read the properties file
+        Scanner scanner = new Scanner(new File(QueleaProperties.get().getQueleaUserHome(), "quelea.properties"));
+        ArrayList<String> propertyKeys = new ArrayList<>();
+        // read all property keys
+        while(scanner.hasNextLine()){
+            String line = scanner.nextLine();
+            if(line.charAt(0) != '#') {
+                propertyKeys.add(line.split("=")[0]);
+            }
+        }
+        // make a copy of key properties
+        ArrayList<String> propertyKeysSorted = new ArrayList<>(propertyKeys);
+        // sort the copy
+        Collections.sort(propertyKeysSorted);
+        // If both are equal then keys were already in sorted order
+        Assert.assertEquals(propertyKeys, propertyKeysSorted);
+    }
+
+}

--- a/Quelea/src/test/java/org/quelea/services/utils/QueleaPropertiesTest.java
+++ b/Quelea/src/test/java/org/quelea/services/utils/QueleaPropertiesTest.java
@@ -1,7 +1,8 @@
 package org.quelea.services.utils;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -9,9 +10,11 @@ import java.util.ArrayList;
 import java.util.Scanner;
 import java.util.Collections;
 
+@DisplayName("QueleaPropertiesTest")
 public class QueleaPropertiesTest {
 
     @Test
+    @DisplayName("Test If Properties File Is Sorted")
     // check whether properties file is sorted
     public void testIfPropertiesFileIsSorted() throws FileNotFoundException {
         // init properties
@@ -33,7 +36,6 @@ public class QueleaPropertiesTest {
         // sort the copy
         Collections.sort(propertyKeysSorted);
         // If both are equal then keys were already in sorted order
-        Assert.assertEquals(propertyKeys, propertyKeysSorted);
+        Assertions.assertEquals(propertyKeys, propertyKeysSorted);
     }
-
 }


### PR DESCRIPTION
Fixes #279 

Extending `QueleaProperties` from `org.apache.commons.collections4.properties.SortedProperties` instead of `java.util.Properties` achieves the end result of sorting the properties file on exit.

The overhead of sorting the properties on every write is low (as discussed).