### PR TITLE
Add background color around text 

### DIFF
--- a/Quelea/src/main/java/org/quelea/services/utils/QueleaProperties.java
+++ b/Quelea/src/main/java/org/quelea/services/utils/QueleaProperties.java
@@ -1518,6 +1518,29 @@ public final class QueleaProperties extends SortedProperties {
         return getColor(getProperty(stageChordColorKey, "200,200,200"));
     }
 
+
+    /**
+     * Get the colour used to display chords in stage view.
+     * <p>
+     *
+     * @return the colour used to display chords in stage view.
+     */
+    public Color getTextBackgroundColor() {
+        return getColor(getProperty(lyricsTextBackgroundColor));
+    }
+
+
+    /**
+     * Determine whether to advance the scheudle item when the current item is
+     * sent live.
+     * <p>
+     *
+     * @return true if we should auto-advance, false otherwise.
+     */
+    public boolean getTextBackgroundEnable() {
+        return Boolean.parseBoolean(getProperty(lyricsTextBackgroundEnable, "false"));
+    }
+
     /**
      * Set the colour used to display chords in stage view.
      * <p>

--- a/Quelea/src/main/java/org/quelea/services/utils/QueleaPropertyKeys.java
+++ b/Quelea/src/main/java/org/quelea/services/utils/QueleaPropertyKeys.java
@@ -62,6 +62,8 @@ public class QueleaPropertyKeys {
     public static final String displaySonginfotextKey = "display.songinfotext";
     public static final String defaultBibleKey = "default.bible";
     public static final String stageChordColorKey = "stage.chord.color";
+    public static final String lyricsTextBackgroundEnable = "lyrics.text.background.enable";
+    public static final String lyricsTextBackgroundColor = "lyrics.text.background.color";
     public static final String stageLyricsColorKey = "stage.lyrics.color";
     public static final String stageBackgroundColorKey = "stage.background.color";
     public static final String activeSelectionColorKey = "active.selection.color";

--- a/Quelea/src/main/java/org/quelea/windows/lyrics/LyricDrawer.java
+++ b/Quelea/src/main/java/org/quelea/windows/lyrics/LyricDrawer.java
@@ -35,6 +35,9 @@ import javafx.scene.effect.ColorAdjust;
 import javafx.scene.effect.DropShadow;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
+import javafx.scene.layout.Background;
+import javafx.scene.layout.BackgroundFill;
+import javafx.scene.layout.CornerRadii;
 import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Color;
 import javafx.scene.text.Font;
@@ -246,8 +249,12 @@ public class LyricDrawer extends WordDrawer {
                 loopMetrics = metrics;
             }
             FormattedText t;
-            t = new FormattedText(line.getLine());
-
+            if (QueleaProperties.get().getTextBackgroundEnable()) {
+                t = new FormattedText(" " + line.getLine() + " ");
+                t.setBackground(new Background(new BackgroundFill(QueleaProperties.get().getTextBackgroundColor(), CornerRadii.EMPTY, Insets.EMPTY)));
+            } else {
+                t = new FormattedText(line.getLine());
+            }
             if (line.isTranslateLine()) {
                 t.setFont(translateFont);
             } else {


### PR DESCRIPTION
Doing live streaming showing worship texts above camera feed, it can be hard to read text.  Adding a background color around the text helps a lot.
Adding quela.properties settings like
`lyrics.text.background.color=80,80,80`
`lyrics.text.background.enable=true`

adds a grey background. Having a black background and white text will allow video mixing equipment to luma key a nice semi transparent background around the text.  
I like having extra space in the beginning and end of the line, but codewise there might be better solutions.