### PR TITLE
Add ability to hide stage clock - resolves #329

### DIFF
--- a/Quelea/languages/gb.lang
+++ b/Quelea/languages/gb.lang
@@ -612,6 +612,7 @@ rcs.song.search=Song
 rcs.bible.search=Bible
 rcs.search=Search and Add
 show.video.library.panel=Show Video Library Tab (requires restart)
+stage.show.clock=Show Clock
 use.24h.clock=Use 24H Clock
 split.bible.verses=Keep verses whole across slides
 no.verse.title=No verse found

--- a/Quelea/src/main/java/org/quelea/services/utils/QueleaProperties.java
+++ b/Quelea/src/main/java/org/quelea/services/utils/QueleaProperties.java
@@ -2259,6 +2259,8 @@ public final class QueleaProperties extends SortedProperties {
         return Integer.parseInt(getProperty(autoDetectPortKey, "50015"));
     }
 
+    public boolean getStageShowClock() { return Boolean.parseBoolean(getProperty(stageShowClockKey, "true")); }
+
     public boolean getUse24HourClock() {
         return Boolean.parseBoolean(getProperty(use24hClockKey, "true"));
     }

--- a/Quelea/src/main/java/org/quelea/services/utils/QueleaPropertyKeys.java
+++ b/Quelea/src/main/java/org/quelea/services/utils/QueleaPropertyKeys.java
@@ -106,6 +106,7 @@ public class QueleaPropertyKeys {
     public static final String clearStageviewWithMainKey = "clear.stageview.with.main";
     public static final String songOverflowKey = "song.overflow";
     public static final String autoDetectPortKey = "auto.detect.port";
+    public static final String stageShowClockKey = "stage.show.clock";
     public static final String use24hClockKey = "use.24h.clock";
     public static final String splitBibleVersesKey = "split.bible.verses";
     public static final String lyricWidthBoundKey = "lyric.width.bound";

--- a/Quelea/src/main/java/org/quelea/windows/lyrics/LyricDrawer.java
+++ b/Quelea/src/main/java/org/quelea/windows/lyrics/LyricDrawer.java
@@ -94,6 +94,9 @@ public class LyricDrawer extends WordDrawer {
         Utils.checkFXThread();
         if (defaultFontSize < 1) {
             defaultFontSize = QueleaProperties.get().getMaxFontSize();
+
+            // Scale the default font size for this canvas
+            defaultFontSize *= CanvasScalingFactor();
         }
         if (getCanvas().getCanvasBackground() != null) {
             if (!getCanvas().getChildren().contains(getCanvas().getCanvasBackground())
@@ -576,6 +579,10 @@ public class LyricDrawer extends WordDrawer {
             return -1;
         }
 
+        // Retrieve and scale the max font size for this canvas
+        double maxFontSizeForCanvas = QueleaProperties.get().getMaxFontSize();
+        maxFontSizeForCanvas *= CanvasScalingFactor();
+
         int width = (int) (getCanvas().getWidth() * QueleaProperties.get().getLyricWidthBounds());
         int height = (int) (getCanvas().getHeight() * QueleaProperties.get().getLyricHeightBounds());
 
@@ -593,7 +600,7 @@ public class LyricDrawer extends WordDrawer {
         font = Font.font(font.getName(),
                 theme.isBold() ? FontWeight.BOLD : FontWeight.NORMAL,
                 theme.isItalic() ? FontPosture.ITALIC : FontPosture.REGULAR,
-                QueleaProperties.get().getMaxFontSize());
+                maxFontSizeForCanvas);
         double fontSize = Double.POSITIVE_INFINITY;
         for (int i = 0; i < displayable.getSections().length; i++) {
             TextSection section = displayable.getSections()[i];

--- a/Quelea/src/main/java/org/quelea/windows/main/WordDrawer.java
+++ b/Quelea/src/main/java/org/quelea/windows/main/WordDrawer.java
@@ -303,4 +303,23 @@ public abstract class WordDrawer extends DisplayableDrawer {
 
         return font.getSize();
     }
+
+    /**
+     * Returns a scaling factor for the canvas of this WordDrawer. This is the scale of this canvas when
+     * compared to the canvas of the Projection Window. Using this scaling factor is it possible to
+     * calculate the sizes of things on a preview/live when compared to the Projection Window.
+     * For example the Maximum Font Size needs to be scaled for the preview/live displays.
+     * <p>
+     * @return The scaling factor for this canvas
+     */
+    protected double CanvasScalingFactor() {
+        double scalingFactor = 1;
+
+        // If there is a projection window, and it has some size (avoid divide by zero errors!)
+        if (QueleaApp.get().getProjectionWindow() != null && QueleaApp.get().getProjectionWindow().getWidth() != 0) {
+            scalingFactor = getCanvas().getWidth() / QueleaApp.get().getProjectionWindow().getWidth();
+        }
+
+        return scalingFactor;
+    }
 }

--- a/Quelea/src/main/java/org/quelea/windows/main/widgets/Clock.java
+++ b/Quelea/src/main/java/org/quelea/windows/main/widgets/Clock.java
@@ -54,18 +54,31 @@ public class Clock extends Text {
                     Calendar time = Calendar.getInstance();
                     String hourString;
                     boolean s24h = QueleaProperties.get().getUse24HourClock();
-                    if (s24h) {
-                        hourString = pad(2, '0', time.get(Calendar.HOUR_OF_DAY) + "");
-                    } else {
-                        hourString = pad(2, '0', time.get(Calendar.HOUR) + "");
+
+                    // Get user visibility setting. There is only one clock at the moment but if there are
+                    // ever more clocks we will need to tell the constructor which clock we are looking at
+                    // to get the correct property
+                    boolean sShowClock = QueleaProperties.get().getStageShowClock();
+
+                    // Only bother updating the text is we are actually showing the clock
+                    if( sShowClock ) {
+                        if (s24h) {
+                            hourString = pad(2, '0', time.get(Calendar.HOUR_OF_DAY) + "");
+                        } else {
+                            hourString = pad(2, '0', time.get(Calendar.HOUR) + "");
+                        }
+                        String minuteString = pad(2, '0', time.get(Calendar.MINUTE) + "");
+                        String text1 = hourString + ":" + minuteString;
+                        if (!s24h) {
+                            text1 += (time.get(Calendar.AM_PM) == Calendar.AM) ? " AM" : " PM";
+                        }
+                        setText(text1);
                     }
-                    String minuteString = pad(2, '0', time.get(Calendar.MINUTE) + "");
-                    String text1 = hourString + ":" + minuteString;
-            if (!s24h) {
-                text1 += (time.get(Calendar.AM_PM) == Calendar.AM) ? " AM" : " PM";
-            }
-            setText(text1);
-        }),
+
+                    // Set visibility after updating the text as otherwise we might get a slight glitch when turning
+                    // the clock from hidden to visible!
+                    setVisible( sShowClock );
+                }),
                 new KeyFrame(Duration.seconds(1))
         );
         timeline.setCycleCount(Animation.INDEFINITE);

--- a/Quelea/src/main/java/org/quelea/windows/main/widgets/DisplayPreview.java
+++ b/Quelea/src/main/java/org/quelea/windows/main/widgets/DisplayPreview.java
@@ -73,24 +73,24 @@ public class DisplayPreview extends StackPane {
     }
 
     /**
-     * Calculate and update the new size of the display canvas.
+     * Calculate and update the new size of the display canvas. This maintains the same
+     * aspect ratio as the projection window.
      */
     private void updateSize() {
-        double width = getWidth();
-        double height = getHeight();
+        // For working out the current ratio, subtract 20 from width and height because
+        // this is the minimum margin amount (10 on each side), otherwise the ratio being
+        // calculate is of the whole split pane section not the actual preview/live display
+        double width = getWidth() - 20;
+        double height = getHeight() - 20;
         double currentRatio = width / height;
         double ratio = getRatio();
         if (currentRatio < ratio) { //height too big
-            double hDiff = (getHeight() - (width / ratio)) / 2;
-            if (hDiff < 10) {
-                hDiff = 10;
-            }
+            double hDiff = (height - (width / ratio)) / 2;
+            hDiff += 10;  // Add back the minimum margin on each side
             setMargin(canvas, new Insets(hDiff, 10, hDiff, 10));
         } else { //width too big
-            double vDiff = (getWidth() - (ratio * height)) / 2;
-            if (vDiff < 10) {
-                vDiff = 10;
-            }
+            double vDiff = (width - (ratio * height)) / 2;
+            vDiff += 10;  // Add back the minimum margin on each side
             setMargin(canvas, new Insets(10, vDiff, 10, vDiff));
         }
     }

--- a/Quelea/src/main/java/org/quelea/windows/options/OptionsStageViewPanel.java
+++ b/Quelea/src/main/java/org/quelea/windows/options/OptionsStageViewPanel.java
@@ -79,6 +79,7 @@ public class OptionsStageViewPanel {
                 getColorPicker(LabelGrabber.INSTANCE.getLabel("stage.lyrics.colour"), QueleaProperties.get().getStageLyricsColor()).customKey(stageLyricsColorKey),
                 getColorPicker(LabelGrabber.INSTANCE.getLabel("stage.chord.colour"), QueleaProperties.get().getStageChordColor()).customKey(stageChordColorKey),
                 Setting.of(LabelGrabber.INSTANCE.getLabel("clear.stage.view"), new SimpleBooleanProperty(QueleaProperties.get().getClearStageWithMain())).customKey(clearStageviewWithMainKey),
+                Setting.of(LabelGrabber.INSTANCE.getLabel("stage.show.clock"), new SimpleBooleanProperty(QueleaProperties.get().getStageShowClock())).customKey(stageShowClockKey),
                 Setting.of(LabelGrabber.INSTANCE.getLabel("use.24h.clock"), new SimpleBooleanProperty(QueleaProperties.get().getUse24HourClock())).customKey(use24hClockKey)
         );
     }


### PR DESCRIPTION
Ability to hide stage clock. Whenever the clock is to be redrawn (once a second), check whether the user has set it to be shown or hidden and act accordingly. Could optimise this slightly by caching the previous visibility of the clock to avoid calling setVisibility each second, but that makes the code more complex for probably minimal gain in performance.