### PR TITLE
Scale max font size for preview/live displays - fixes #244

### DIFF
--- a/Quelea/src/main/java/org/quelea/windows/lyrics/LyricDrawer.java
+++ b/Quelea/src/main/java/org/quelea/windows/lyrics/LyricDrawer.java
@@ -96,7 +96,7 @@ public class LyricDrawer extends WordDrawer {
             defaultFontSize = QueleaProperties.get().getMaxFontSize();
 
             // Scale the default font size for this canvas
-            defaultFontSize *= CanvasScalingFactor();
+            defaultFontSize *= canvasScalingFactor();
         }
         if (getCanvas().getCanvasBackground() != null) {
             if (!getCanvas().getChildren().contains(getCanvas().getCanvasBackground())
@@ -581,7 +581,7 @@ public class LyricDrawer extends WordDrawer {
 
         // Retrieve and scale the max font size for this canvas
         double maxFontSizeForCanvas = QueleaProperties.get().getMaxFontSize();
-        maxFontSizeForCanvas *= CanvasScalingFactor();
+        maxFontSizeForCanvas *= canvasScalingFactor();
 
         int width = (int) (getCanvas().getWidth() * QueleaProperties.get().getLyricWidthBounds());
         int height = (int) (getCanvas().getHeight() * QueleaProperties.get().getLyricHeightBounds());

--- a/Quelea/src/main/java/org/quelea/windows/lyrics/LyricDrawer.java
+++ b/Quelea/src/main/java/org/quelea/windows/lyrics/LyricDrawer.java
@@ -94,6 +94,9 @@ public class LyricDrawer extends WordDrawer {
         Utils.checkFXThread();
         if (defaultFontSize < 1) {
             defaultFontSize = QueleaProperties.get().getMaxFontSize();
+
+            // Scale the default font size for this canvas
+            defaultFontSize *= CanvasScalingFactor();
         }
         if (getCanvas().getCanvasBackground() != null) {
             if (!getCanvas().getChildren().contains(getCanvas().getCanvasBackground())
@@ -576,6 +579,10 @@ public class LyricDrawer extends WordDrawer {
             return -1;
         }
 
+        // Retrieve and scale the max font size for this canvas
+        double maxFontSizeForCanvas = QueleaProperties.get().getMaxFontSize();
+        maxFontSizeForCanvas *= CanvasScalingFactor();
+
         int width = (int) (getCanvas().getWidth() * QueleaProperties.get().getLyricWidthBounds());
         int height = (int) (getCanvas().getHeight() * QueleaProperties.get().getLyricHeightBounds());
 
@@ -593,7 +600,7 @@ public class LyricDrawer extends WordDrawer {
         font = Font.font(font.getName(),
                 theme.isBold() ? FontWeight.BOLD : FontWeight.NORMAL,
                 theme.isItalic() ? FontPosture.ITALIC : FontPosture.REGULAR,
-                QueleaProperties.get().getMaxFontSize());
+                maxFontSizeForCanvas);
         double fontSize = Double.POSITIVE_INFINITY;
         for (int i = 0; i < displayable.getSections().length; i++) {
             TextSection section = displayable.getSections()[i];

--- a/Quelea/src/main/java/org/quelea/windows/main/WordDrawer.java
+++ b/Quelea/src/main/java/org/quelea/windows/main/WordDrawer.java
@@ -312,7 +312,7 @@ public abstract class WordDrawer extends DisplayableDrawer {
      * <p>
      * @return The scaling factor for this canvas
      */
-    protected double CanvasScalingFactor() {
+    protected double canvasScalingFactor() {
         double scalingFactor = 1;
 
         // If there is a projection window, and it has some size (avoid divide by zero errors!)

--- a/Quelea/src/main/java/org/quelea/windows/main/WordDrawer.java
+++ b/Quelea/src/main/java/org/quelea/windows/main/WordDrawer.java
@@ -303,4 +303,23 @@ public abstract class WordDrawer extends DisplayableDrawer {
 
         return font.getSize();
     }
+
+    /**
+     * Returns a scaling factor for the canvas of this WordDrawer. This is the scale of this canvas when
+     * compared to the canvas of the Projection Window. Using this scaling factor is it possible to
+     * calculate the sizes of things on a preview/live when compared to the Projection Window.
+     * For example the Maximum Font Size needs to be scaled for the preview/live displays.
+     * <p>
+     * @return The scaling factor for this canvas
+     */
+    protected double CanvasScalingFactor() {
+        double scalingFactor = 1;
+
+        // If there is a projection window, and it has some size (avoid divide by zero errors!)
+        if (QueleaApp.get().getProjectionWindow() != null && QueleaApp.get().getProjectionWindow().getWidth() != 0) {
+            scalingFactor = getCanvas().getWidth() / QueleaApp.get().getProjectionWindow().getWidth();
+        }
+
+        return scalingFactor;
+    }
 }


### PR DESCRIPTION
The max font size setting is really for how big the font should be on the projection display. For the preview/live display is needs to be scaled so that it proportionally looks the same.