### PR TITLE
Correct calculation of live/preview display size

### DIFF
--- a/Quelea/src/main/java/org/quelea/windows/main/widgets/DisplayPreview.java
+++ b/Quelea/src/main/java/org/quelea/windows/main/widgets/DisplayPreview.java
@@ -73,24 +73,24 @@ public class DisplayPreview extends StackPane {
     }
 
     /**
-     * Calculate and update the new size of the display canvas.
+     * Calculate and update the new size of the display canvas. This maintains the same
+     * aspect ratio as the projection window.
      */
     private void updateSize() {
-        double width = getWidth();
-        double height = getHeight();
+        // For working out the current ratio, subtract 20 from width and height because
+        // this is the minimum margin amount (10 on each side), otherwise the ratio being
+        // calculate is of the whole split pane section not the actual preview/live display
+        double width = getWidth() - 20;
+        double height = getHeight() - 20;
         double currentRatio = width / height;
         double ratio = getRatio();
         if (currentRatio < ratio) { //height too big
-            double hDiff = (getHeight() - (width / ratio)) / 2;
-            if (hDiff < 10) {
-                hDiff = 10;
-            }
+            double hDiff = (height - (width / ratio)) / 2;
+            hDiff += 10;  // Add back the minimum margin on each side
             setMargin(canvas, new Insets(hDiff, 10, hDiff, 10));
         } else { //width too big
-            double vDiff = (getWidth() - (ratio * height)) / 2;
-            if (vDiff < 10) {
-                vDiff = 10;
-            }
+            double vDiff = (width - (ratio * height)) / 2;
+            vDiff += 10;  // Add back the minimum margin on each side
             setMargin(canvas, new Insets(10, vDiff, 10, vDiff));
         }
     }


### PR DESCRIPTION
There was a subtle(ish) bug in the calculation of the size of the live/preview displays. The ratio of the display was being calculated based on the full size of the split pane canvas that the live/preview display was in. This was then being used to calculate the margins to apply to the canvas to get the actual live/preview being the correct ratio. This was close, but not actually correct when the minimum of 10px margin was taken into account. What should actually be done is subtract the 10px margin from the size of the canvas and then work out what extra margin is needed in addition to the 10px to get a live/preview that is the same ratio as the projection window.

This fix helps towards #116, but is not a total fix for that issue, but worth having on its own anyway!