### PR TITLE
Add ability to hide stage clock - resolves #329

### DIFF
--- a/Quelea/changelogs/changelog-2021.0.txt
+++ b/Quelea/changelogs/changelog-2021.0.txt
@@ -4,3 +4,4 @@ quelea (2021.0) stable
   * Church CCLI num can now be specified in options dialog
   * Support OSIS XML bible format
   * Song list export now also includes song CCLI number (where specified)
+  * Add ability to hide stage clock

--- a/Quelea/languages/gb.lang
+++ b/Quelea/languages/gb.lang
@@ -612,6 +612,7 @@ rcs.song.search=Song
 rcs.bible.search=Bible
 rcs.search=Search and Add
 show.video.library.panel=Show Video Library Tab (requires restart)
+stage.show.clock=Show Clock
 use.24h.clock=Use 24H Clock
 split.bible.verses=Keep verses whole across slides
 no.verse.title=No verse found

--- a/Quelea/src/main/java/org/quelea/services/utils/QueleaProperties.java
+++ b/Quelea/src/main/java/org/quelea/services/utils/QueleaProperties.java
@@ -2259,6 +2259,8 @@ public final class QueleaProperties extends SortedProperties {
         return Integer.parseInt(getProperty(autoDetectPortKey, "50015"));
     }
 
+    public boolean getStageShowClock() { return Boolean.parseBoolean(getProperty(stageShowClockKey, "true")); }
+
     public boolean getUse24HourClock() {
         return Boolean.parseBoolean(getProperty(use24hClockKey, "true"));
     }

--- a/Quelea/src/main/java/org/quelea/services/utils/QueleaPropertyKeys.java
+++ b/Quelea/src/main/java/org/quelea/services/utils/QueleaPropertyKeys.java
@@ -106,6 +106,7 @@ public class QueleaPropertyKeys {
     public static final String clearStageviewWithMainKey = "clear.stageview.with.main";
     public static final String songOverflowKey = "song.overflow";
     public static final String autoDetectPortKey = "auto.detect.port";
+    public static final String stageShowClockKey = "stage.show.clock";
     public static final String use24hClockKey = "use.24h.clock";
     public static final String splitBibleVersesKey = "split.bible.verses";
     public static final String lyricWidthBoundKey = "lyric.width.bound";

--- a/Quelea/src/main/java/org/quelea/windows/main/widgets/Clock.java
+++ b/Quelea/src/main/java/org/quelea/windows/main/widgets/Clock.java
@@ -54,18 +54,31 @@ public class Clock extends Text {
                     Calendar time = Calendar.getInstance();
                     String hourString;
                     boolean s24h = QueleaProperties.get().getUse24HourClock();
-                    if (s24h) {
-                        hourString = pad(2, '0', time.get(Calendar.HOUR_OF_DAY) + "");
-                    } else {
-                        hourString = pad(2, '0', time.get(Calendar.HOUR) + "");
+
+                    // Get user visibility setting. There is only one clock at the moment but if there are
+                    // ever more clocks we will need to tell the constructor which clock we are looking at
+                    // to get the correct property
+                    boolean sShowClock = QueleaProperties.get().getStageShowClock();
+
+                    // Only bother updating the text is we are actually showing the clock
+                    if( sShowClock ) {
+                        if (s24h) {
+                            hourString = pad(2, '0', time.get(Calendar.HOUR_OF_DAY) + "");
+                        } else {
+                            hourString = pad(2, '0', time.get(Calendar.HOUR) + "");
+                        }
+                        String minuteString = pad(2, '0', time.get(Calendar.MINUTE) + "");
+                        String text1 = hourString + ":" + minuteString;
+                        if (!s24h) {
+                            text1 += (time.get(Calendar.AM_PM) == Calendar.AM) ? " AM" : " PM";
+                        }
+                        setText(text1);
                     }
-                    String minuteString = pad(2, '0', time.get(Calendar.MINUTE) + "");
-                    String text1 = hourString + ":" + minuteString;
-            if (!s24h) {
-                text1 += (time.get(Calendar.AM_PM) == Calendar.AM) ? " AM" : " PM";
-            }
-            setText(text1);
-        }),
+
+                    // Set visibility after updating the text as otherwise we might get a slight glitch when turning
+                    // the clock from hidden to visible!
+                    setVisible( sShowClock );
+                }),
                 new KeyFrame(Duration.seconds(1))
         );
         timeline.setCycleCount(Animation.INDEFINITE);

--- a/Quelea/src/main/java/org/quelea/windows/options/OptionsStageViewPanel.java
+++ b/Quelea/src/main/java/org/quelea/windows/options/OptionsStageViewPanel.java
@@ -79,6 +79,7 @@ public class OptionsStageViewPanel {
                 getColorPicker(LabelGrabber.INSTANCE.getLabel("stage.lyrics.colour"), QueleaProperties.get().getStageLyricsColor()).customKey(stageLyricsColorKey),
                 getColorPicker(LabelGrabber.INSTANCE.getLabel("stage.chord.colour"), QueleaProperties.get().getStageChordColor()).customKey(stageChordColorKey),
                 Setting.of(LabelGrabber.INSTANCE.getLabel("clear.stage.view"), new SimpleBooleanProperty(QueleaProperties.get().getClearStageWithMain())).customKey(clearStageviewWithMainKey),
+                Setting.of(LabelGrabber.INSTANCE.getLabel("stage.show.clock"), new SimpleBooleanProperty(QueleaProperties.get().getStageShowClock())).customKey(stageShowClockKey),
                 Setting.of(LabelGrabber.INSTANCE.getLabel("use.24h.clock"), new SimpleBooleanProperty(QueleaProperties.get().getUse24HourClock())).customKey(use24hClockKey)
         );
     }


### PR DESCRIPTION
Ability to hide stage clock. Whenever the clock is to be redrawn (once a second), check whether the user has set it to be shown or hidden and act accordingly. Could optimise this slightly by caching the previous visibility of the clock to avoid calling setVisibility each second, but that makes the code more complex for probably minimal gain in performance.