### PR TITLE
Fix visibility of prompt-text - Dark Mode

### DIFF
--- a/Quelea/src/main/java/org/quelea/windows/timer/CreateTimerPanel.java
+++ b/Quelea/src/main/java/org/quelea/windows/timer/CreateTimerPanel.java
@@ -106,6 +106,9 @@ public class CreateTimerPanel extends Stage {
         durationTextField = new TextField();
         durationTextField.setTooltip(new Tooltip(LabelGrabber.INSTANCE.getLabel("duration.tooltip.label")));
         durationTextField.setPromptText("5:00");
+        if (QueleaProperties.get().getUseDarkTheme()) {
+            durationTextField.setStyle("-fx-prompt-text-fill: #404040");
+        }
         durationTextField.textProperty().addListener((ObservableValue<? extends String> observable, String oldValue, String newValue) -> {
             if (parsable(newValue)) {
                 if (!QueleaProperties.get().getUseDarkTheme()) {
@@ -131,6 +134,9 @@ public class CreateTimerPanel extends Stage {
         textTextArea.setPrefRowCount(4);
         textTextArea.setPrefColumnCount(30);
         textTextArea.setPromptText(LabelGrabber.INSTANCE.getLabel("timer.text.prompt"));
+        if (QueleaProperties.get().getUseDarkTheme()) {
+            textTextArea.setStyle("-fx-prompt-text-fill: #404040");
+        }
         textLabel.setLabelFor(textTextArea);
         GridPane.setConstraints(textTextArea, 1, rows);
         grid.getChildren().add(textTextArea);


### PR DESCRIPTION
This will allow for the text in the add timer menu to become clearer and visible to see. 
At current, the prompt-text when using dark mode is almost impossible to see, and blends in with the colour of the text-box. 
There is not the same problem for light mode in this regard, so the text colour change only affects dark mode.

Hopefully this is a easy fix to the problem, and obviously if the colour of the text is too dark/bright you can change that.

Before:
![Screenshot 2021-02-14 at 22 45 22](https://user-images.githubusercontent.com/76561460/107891402-54f15d80-6f16-11eb-89bb-ed7e75e7a62c.png)

After:
![Screenshot 2021-02-14 at 22 46 27](https://user-images.githubusercontent.com/76561460/107891428-7ce0c100-6f16-11eb-9d1e-7e44496b61a1.png)
