### PR TITLE
Remove unnecessary stream() call

### DIFF
--- a/Quelea/src/main/java/org/quelea/windows/main/schedule/ScheduleList.java
+++ b/Quelea/src/main/java/org/quelea/windows/main/schedule/ScheduleList.java
@@ -279,7 +279,7 @@ public class ScheduleList extends StackPane {
 
         Dragboard db = event.getDragboard();
         if (db.hasFiles()) {
-            db.getFiles().stream().forEach((file) -> {
+            db.getFiles().forEach((file) -> {
                 if (Utils.fileIsImage(file)) {
                     add(new ImageDisplayable(file));
                 } else if (Utils.fileIsVideo(file)) {


### PR DESCRIPTION
Closes #398

Removed the unnecessary stream() call before foreach(...) for db.getFiles() in ScheduleList.java