### PR TITLE
Removed unnecessary boolean unboxing; closes #412

### DIFF
--- a/Quelea/src/main/java/org/quelea/data/bible/BibleSearchDialog.java
+++ b/Quelea/src/main/java/org/quelea/data/bible/BibleSearchDialog.java
@@ -148,7 +148,7 @@ public class BibleSearchDialog extends Stage implements BibleChangeListener {
         searchField.focusedProperty().addListener(new ChangeListener<Boolean>() {
             @Override
             public void changed(ObservableValue<? extends Boolean> ov, Boolean t, Boolean t1) {
-                if (t1.booleanValue()) {
+                if (t1) {
                     searchField.setText("");
                     searchField.focusedProperty().removeListener(this);
                 }

--- a/Quelea/src/main/java/org/quelea/utils/BigDecimalTextField.java
+++ b/Quelea/src/main/java/org/quelea/utils/BigDecimalTextField.java
@@ -83,7 +83,7 @@ public class BigDecimalTextField extends TextField {
 
             @Override
             public void changed(ObservableValue<? extends Boolean> observable, Boolean oldValue, Boolean newValue) {
-                if (!newValue.booleanValue()) {
+                if (!newValue) {
                     parseAndFormatInput();
                 }
             }

--- a/Quelea/src/main/java/org/quelea/windows/main/widgets/NumberTextField.java
+++ b/Quelea/src/main/java/org/quelea/windows/main/widgets/NumberTextField.java
@@ -82,7 +82,7 @@ public class NumberTextField extends TextField {
         focusedProperty().addListener(new ChangeListener<Boolean>() {
             @Override
             public void changed(ObservableValue<? extends Boolean> observable, Boolean oldValue, Boolean newValue) {
-                if(!newValue.booleanValue()) {
+                if(!newValue) {
                     parseAndFormatInput();
                 }
             }

--- a/Quelea/src/main/java/org/quelea/windows/multimedia/VLCWindowDirect.java
+++ b/Quelea/src/main/java/org/quelea/windows/multimedia/VLCWindowDirect.java
@@ -107,7 +107,7 @@ public class VLCWindowDirect extends VLCWindow {
                             PlatformUtils.setFullScreenAlwaysOnTop(stage, true);
                             stage.focusedProperty().addListener(new ChangeListener<Boolean>() {
                                 public void changed(ObservableValue<? extends Boolean> observable, Boolean oldValue, Boolean newValue) {
-                                    if (newValue.booleanValue()) {
+                                    if (newValue) {
                                         //focused
                                         stage.toBack();
                                     } else {


### PR DESCRIPTION
There were 4 places in the code we're unnecessarily unboxing boolean values (by using `.booleanValue()`) - this has been unnecessary since Java 5, so the `.booleanValue()` method calls can simply be deleted.