### PR TITLE
Use Integer.compare & lambda instead of comparing manually

### DIFF
--- a/Quelea/src/main/java/org/quelea/services/utils/LineTypeChecker.java
+++ b/Quelea/src/main/java/org/quelea/services/utils/LineTypeChecker.java
@@ -139,19 +139,7 @@ public class LineTypeChecker {
     }
 
     private static final TreeMap<String, String> titleMap = new TreeMap<>();
-    private static final TreeMap<String, String> titleMapRev = new TreeMap<>(new Comparator<String>() {
-
-        @Override
-        public int compare(String o1, String o2) {
-            if (o1.length() > o2.length()) {
-                return -1;
-            }
-            if (o1.length() == o2.length()) {
-                return 0;
-            }
-            return 1;
-        }
-    });
+    private static final TreeMap<String, String> titleMapRev = new TreeMap<>((o1, o2) -> Integer.compare(o2.length(), o1.length()));
 
     private static int hashLength = 3;
 


### PR DESCRIPTION
Refactoring - LineTypeChecker class
- The implementation of the manual integer comparison is refactored, now the "Comparator" instance is replaced by a lambda and by the use of "Integer.compare()".

Issues #415 
