### PR TITLE
Replace manual checking with `Math.min()` call

### DIFF
--- a/Quelea/src/main/java/org/quelea/services/utils/Version.java
+++ b/Quelea/src/main/java/org/quelea/services/utils/Version.java
@@ -142,13 +142,7 @@ public class Version implements Comparable<Version> {
     public int compareTo(Version o) {
         String[] theseParts = versionStr.split("\\.");
         String[] otherParts = o.versionStr.split("\\.");
-        int minLength;
-        if(theseParts.length < otherParts.length) {
-            minLength = theseParts.length;
-        }
-        else {
-            minLength = otherParts.length;
-        }
+        int minLength = Math.min(theseParts.length, otherParts.length);
         for(int i = 0; i < minLength; i++) {
             int thisNum = Integer.parseInt(theseParts[i]);
             int otherNum = Integer.parseInt(otherParts[i]);


### PR DESCRIPTION
This PR updates version.java to remove manual checking of two integers and uses `Math.min()` to compare them. 

Fixes #422.