### PR TITLE
Remove redundant new File() call

### DIFF
--- a/Quelea/src/main/java/org/quelea/data/powerpoint/PPTPresentation.java
+++ b/Quelea/src/main/java/org/quelea/data/powerpoint/PPTPresentation.java
@@ -42,7 +42,7 @@ public class PPTPresentation implements Presentation {
      * @param file the file containing the presentation.
      */
     public PPTPresentation(String file) throws IOException {
-        slideshow = new HSLFSlideShow(new FileInputStream(new File(file)));
+        slideshow = new HSLFSlideShow(new FileInputStream(file));
         slides = makeSlides();
     }
 

--- a/Quelea/src/main/java/org/quelea/data/powerpoint/PPTXPresentation.java
+++ b/Quelea/src/main/java/org/quelea/data/powerpoint/PPTXPresentation.java
@@ -41,7 +41,7 @@ public class PPTXPresentation implements Presentation {
      * @param file the file containing the presentation.
      */
     public PPTXPresentation(String file) throws IOException {
-        slideshow = new XMLSlideShow(new FileInputStream(new File(file)));
+        slideshow = new XMLSlideShow(new FileInputStream(file));
         slides = makeSlides();
     }
 


### PR DESCRIPTION
This fixes issue #420.

Instead of passing in a `new File()` object, we pass in the `String` instead. 