### PR TITLE
stream io error safety

### DIFF
--- a/Quelea/src/main/java/org/quelea/services/importexport/EasyWorshipParser.java
+++ b/Quelea/src/main/java/org/quelea/services/importexport/EasyWorshipParser.java
@@ -26,6 +26,7 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -56,29 +57,30 @@ public class EasyWorshipParser implements SongParser {
      */
     @Override
     public List<SongDisplayable> getSongs(File file, StatusPanel statusPanel) throws IOException {
-        List<SongDisplayable> ret = new ArrayList<>();
+        LOGGER.log(Level.INFO, "Easyworship importer from {0}", file.getParent());
         try {
             Class.forName("com.googlecode.paradox.Driver");
-            LOGGER.log(Level.INFO, "Easyworship importer from {0}", file.getParent());
-            Connection conn = DriverManager.getConnection("jdbc:paradox:/" + file.getParent());
-            ResultSet rs = conn.createStatement().executeQuery("SELECT * FROM \"Songs.DB\"");
-            while(rs.next()) {
-                String title = rs.getString("Title");
-                String author = rs.getString("Author");
-                if(author == null) {
-                    author = "";
+            try (Connection conn = DriverManager.getConnection("jdbc:paradox:/" + file.getParent());
+                 ResultSet rs = conn.createStatement().executeQuery("SELECT * FROM \"Songs.DB\"")) {
+                List<SongDisplayable> ret = new ArrayList<>();
+                while (rs.next()) {
+                    String title = rs.getString("Title");
+                    String author = rs.getString("Author");
+                    if (author == null) {
+                        author = "";
+                    }
+                    String lyrics = rs.getString("Words");
+                    String copyright = rs.getString("Copyright");
+                    String num = rs.getString("Song Number");
+                    ret.add(getSong(title, author, lyrics, copyright, num));
                 }
-                String lyrics = rs.getString("Words");
-                String copyright = rs.getString("Copyright");
-                String num = rs.getString("Song Number");
-                ret.add(getSong(title, author, lyrics, copyright, num));
+                return ret;
             }
-
         }
         catch(ClassNotFoundException | SQLException ex) {
-            LOGGER.log(Level.INFO, "Couldn't import using SQL from " + file.getParent(), ex);
+            LOGGER.log(Level.INFO, ex, () -> "Couldn't import using SQL from " + file.getParent());
+            return Collections.emptyList();
         }
-        return ret;
     }
 
     private SongDisplayable getSong(String title, String author, String songContent, String copyright, String ccli) {

--- a/Quelea/src/main/java/org/quelea/services/importexport/EpicWorshipParser.java
+++ b/Quelea/src/main/java/org/quelea/services/importexport/EpicWorshipParser.java
@@ -44,55 +44,56 @@ public class EpicWorshipParser implements SongParser {
 
     @Override
     public List<SongDisplayable> getSongs(File location, StatusPanel statusPanel) throws IOException {
-        BufferedReader bfr = new BufferedReader(new InputStreamReader(new FileInputStream(location), Utils.getEncoding(location)));
-        ArrayList<SongDisplayable> ret = new ArrayList<>();
-        String fullContents = bfr.readLine();
-        String songsWhole = fullContents.substring(10, fullContents.length() - 2);
-        String[] songInfoList = songsWhole.split("\\},\\{");
-        for (String songInfo : songInfoList) {
-            songInfo = songInfo.replace("{", "").replace("{", "");
-            Matcher m1 = NAME.matcher(songInfo);
-            String name = "";
-            String author = "";
-            String lyrics = "";
-            if (m1.find()) {
-                name = m1.group(0);
-                name = format(name);
-            }
-
-            Matcher m2 = AUTHOR.matcher(songInfo);
-            if (m2.find()) {
-                author = m2.group(0);
-                author = format(author);
-            }
-
-            Matcher m3 = LYRICS.matcher(songInfo);
-            if (m3.find()) {
-                lyrics = m3.group(0);
-                lyrics = format(lyrics);
-            }
-
-            SongDisplayable s = new SongDisplayable(name, author);
-
-            ArrayList<String> section = new ArrayList<>();
-            int sectionCount = 0;
-            String[] lines = lyrics.split("\\\\n");
-            for (String line : lines) {
-                if (!line.isEmpty()) {
-                    section.add(line);
-                } else {
-                    String[] sectionsArray = new String[section.size()];
-                    s.addSection(sectionCount, new TextSection("", section.toArray(sectionsArray), section.toArray(sectionsArray), true));
-                    sectionCount++;
-                    section.clear();
+        try(BufferedReader bfr = new BufferedReader(new InputStreamReader(new FileInputStream(location), Utils.getEncoding(location)))) {
+            ArrayList<SongDisplayable> ret = new ArrayList<>();
+            String fullContents = bfr.readLine();
+            String songsWhole = fullContents.substring(10, fullContents.length() - 2);
+            String[] songInfoList = songsWhole.split("\\},\\{");
+            for (String songInfo : songInfoList) {
+                songInfo = songInfo.replace("{", "").replace("{", "");
+                Matcher m1 = NAME.matcher(songInfo);
+                String name = "";
+                String author = "";
+                String lyrics = "";
+                if (m1.find()) {
+                    name = m1.group(0);
+                    name = format(name);
                 }
-            }
-            String[] sectionsArray = new String[section.size()];
-            s.addSection(sectionCount, new TextSection("", section.toArray(sectionsArray), section.toArray(sectionsArray), true));
 
-            ret.add(s);
+                Matcher m2 = AUTHOR.matcher(songInfo);
+                if (m2.find()) {
+                    author = m2.group(0);
+                    author = format(author);
+                }
+
+                Matcher m3 = LYRICS.matcher(songInfo);
+                if (m3.find()) {
+                    lyrics = m3.group(0);
+                    lyrics = format(lyrics);
+                }
+
+                SongDisplayable s = new SongDisplayable(name, author);
+
+                ArrayList<String> section = new ArrayList<>();
+                int sectionCount = 0;
+                String[] lines = lyrics.split("\\\\n");
+                for (String line : lines) {
+                    if (!line.isEmpty()) {
+                        section.add(line);
+                    } else {
+                        String[] sectionsArray = new String[section.size()];
+                        s.addSection(sectionCount, new TextSection("", section.toArray(sectionsArray), section.toArray(sectionsArray), true));
+                        sectionCount++;
+                        section.clear();
+                    }
+                }
+                String[] sectionsArray = new String[section.size()];
+                s.addSection(sectionCount, new TextSection("", section.toArray(sectionsArray), section.toArray(sectionsArray), true));
+
+                ret.add(s);
+            }
+            return ret;
         }
-        return ret;
     }
 
     private String format(String s) {

--- a/Quelea/src/main/java/org/quelea/services/importexport/SongBeamerParser.java
+++ b/Quelea/src/main/java/org/quelea/services/importexport/SongBeamerParser.java
@@ -55,11 +55,14 @@ public class SongBeamerParser implements SongParser {
     @Override
     public List<SongDisplayable> getSongs(File file, StatusPanel statusPanel) throws IOException {
         List<SongDisplayable> ret = new ArrayList<>();
-        BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), Charset.forName("Cp1250")));
-        String fileLine;
-        StringBuilder rawLinesBuilder = new StringBuilder();
-        while ((fileLine = reader.readLine()) != null) {
-            rawLinesBuilder.append(fileLine).append("\n");
+        StringBuilder rawLinesBuilder;
+        try(BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), Charset.forName(
+                "Cp1250")))) {
+            String fileLine;
+            rawLinesBuilder = new StringBuilder();
+            while ((fileLine = reader.readLine()) != null) {
+                rawLinesBuilder.append(fileLine).append("\n");
+            }
         }
         String rawLines = rawLinesBuilder.toString();
 

--- a/Quelea/src/main/java/org/quelea/services/importexport/WorshipHimParser.java
+++ b/Quelea/src/main/java/org/quelea/services/importexport/WorshipHimParser.java
@@ -49,11 +49,10 @@ public class WorshipHimParser implements SongParser {
     @Override
     public List<SongDisplayable> getSongs(File location, StatusPanel statusPanel) {
         List<SongDisplayable> ret = new ArrayList<>();
-        try {
-            Database d = new DatabaseBuilder()
-                    .setReadOnly(true)
-                    .setFile(location)
-                    .open();
+        try (Database d = new DatabaseBuilder()
+                .setReadOnly(true)
+                .setFile(location)
+                .open()){
 
             Table table = d.getTable("Songs");
             for (Row row : table) {

--- a/Quelea/src/main/java/org/quelea/services/languages/USEnglishConverter.java
+++ b/Quelea/src/main/java/org/quelea/services/languages/USEnglishConverter.java
@@ -18,9 +18,7 @@
  */
 package org.quelea.services.languages;
 
-import java.io.FileReader;
-import java.io.FileWriter;
-import java.io.IOException;
+import java.io.*;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
@@ -34,22 +32,30 @@ import java.util.regex.Pattern;
 public class USEnglishConverter {
 
     public static void main(String[] args) {
-        try {
-            System.out.println("Converting language file to American English...");
-            Properties gb = new Properties();
-            gb.load(new FileReader("languages/gb.lang"));
-            Properties usa = new Properties();
-            for(Object k : gb.keySet()) {
-                String key = (String) k;
-                usa.setProperty(key, translateToUS(gb.getProperty(key)));
-            }
-            usa.setProperty("LANGUAGENAME", "English (US)");
-            usa.store(new FileWriter("languages/us.lang"), "THIS IS AN AUTO GENERATED FILE, AND WILL BE OVERWRITTEN EACH TIME QUELEA IS REBUILT. DO NOT EDIT MANUALLY!");
-            System.out.println("Successfully converted language file to American English.");
-        }
-        catch(IOException ex) {
+        System.out.println("Converting language file to American English...");
+        Properties gb = new Properties();
+        try (Reader reader = new FileReader("languages/gb.lang")) {
+            gb.load(reader);
+        } catch (IOException ex) {
             ex.printStackTrace();
+            return;
         }
+
+
+        Properties usa = new Properties();
+        for (Object k : gb.keySet()) {
+            String key = (String) k;
+            usa.setProperty(key, translateToUS(gb.getProperty(key)));
+        }
+        usa.setProperty("LANGUAGENAME", "English (US)");
+        try (Writer writer = new FileWriter("languages/us.lang")) {
+            usa.store(writer, "THIS IS AN AUTO GENERATED FILE, AND WILL BE OVERWRITTEN EACH TIME QUELEA IS REBUILT. " +
+                    "DO NOT EDIT MANUALLY!");
+        } catch (IOException e) {
+            e.printStackTrace();
+            return;
+        }
+        System.out.println("Successfully converted language file to American English.");
     }
 
     /**

--- a/Quelea/src/main/java/org/quelea/services/languages/spelling/Speller.java
+++ b/Quelea/src/main/java/org/quelea/services/languages/spelling/Speller.java
@@ -25,6 +25,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -74,8 +75,7 @@ public class Speller {
         else {
             words = new HashSet<>();
             dictionaries.put(dict.getDictFile(), words);
-            try {
-                BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(dict.getDictFile()), "UTF-8"));
+            try(BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(dict.getDictFile()), StandardCharsets.UTF_8))) {
                 String line;
                 while((line = reader.readLine()) != null) {
                     line = sanitiseWord(line);
@@ -198,15 +198,14 @@ public class Speller {
      */
     public void addWord(String word) {
         word = sanitiseWord(word);
-        try {
-            if(!words.contains(word)) {
-                words.add(word);
-                BufferedWriter out = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(dict.getDictFile(), true), "UTF-8"));
-                out.append(System.getProperty("line.separator") + word).close();
+        if(!words.contains(word)) {
+            words.add(word);
+            try(BufferedWriter out = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(dict.getDictFile(), true), StandardCharsets.UTF_8))) {
+                out.append(System.getProperty("line.separator")).append(word).close();
             }
-        }
-        catch(IOException ex) {
-            throw new RuntimeException("Couldn't add word to dictionary file", ex);
+            catch(IOException ex) {
+                throw new RuntimeException("Couldn't add word to dictionary file", ex);
+            }
         }
     }
 

--- a/Quelea/src/main/java/org/quelea/services/utils/FontInstaller.java
+++ b/Quelea/src/main/java/org/quelea/services/utils/FontInstaller.java
@@ -28,6 +28,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Stream;
 
 /**
  * Registers the Quelea bundled fonts with the JVM.
@@ -43,8 +44,8 @@ public class FontInstaller {
      */
     public void setupBundledFonts() {
         GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
-        try {
-            Files.list(Paths.get("icons", "bundledfonts")).forEach((Path path) -> {
+        try (Stream<Path> fontFiles = Files.list(Paths.get("icons", "bundledfonts"))){
+            fontFiles.forEach((Path path) -> {
                 File file = path.toFile();
                 if (file.getName().toLowerCase().endsWith("otf") || file.getName().toLowerCase().endsWith("ttf")) {
                     try {


### PR DESCRIPTION
Many places in the codebase lacked proper safety around file and db io operations failures.
Specifically, due to lack of `try-with-resources`, there are potentials for streams staying unclosed after failures.
* Enhanced such instances with `try-with-resources`.
* Made minor cleanups on the way.