### PR TITLE
Allow `file` scheme urls

### DIFF
--- a/Quelea/src/main/java/org/quelea/data/displayable/WebDisplayable.java
+++ b/Quelea/src/main/java/org/quelea/data/displayable/WebDisplayable.java
@@ -18,10 +18,11 @@
 package org.quelea.data.displayable;
 
 import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.scene.Cursor;
 import javafx.scene.image.Image;
@@ -184,11 +185,22 @@ public class WebDisplayable implements Displayable {
     }
 
     public void setUrl(String url) {
-        if (!url.startsWith("http")) {
-            url = "http://" + url;
-        }
+        url = sanitiseUrl(url);
         this.url = url;
         webEngine.load(url);
+    }
+
+    public static String sanitiseUrl(String unsafeUrl) {
+        try {
+            URI uri = new URI(unsafeUrl);
+            if ( uri.getScheme() == null ){
+                uri = new URI("http://"+unsafeUrl);
+            }
+            return uri.toString();
+        }catch(URISyntaxException e){
+            LOGGER.warning("Failed to parse url \""+unsafeUrl+"\" "+e.getMessage());
+            return "https://quelea.org/";
+        }
     }
 
     public void zoom(boolean zoomIn) {

--- a/Quelea/src/main/java/org/quelea/windows/main/actionhandlers/AddWebActionHandler.java
+++ b/Quelea/src/main/java/org/quelea/windows/main/actionhandlers/AddWebActionHandler.java
@@ -50,10 +50,7 @@ public class AddWebActionHandler implements EventHandler<ActionEvent> {
         Optional<String> result = dialog.showAndWait();
         if (result.isPresent()) {
             String url = result.get();
-            if (!url.startsWith("http")) {
-                url = "http://" + url;
-            }
-            WebDisplayable displayable = new WebDisplayable(url);
+            WebDisplayable displayable = new WebDisplayable(WebDisplayable.sanitiseUrl( url ));
             QueleaApp.get().getMainWindow().getMainPanel().getSchedulePanel().getScheduleList().add(displayable);
         }
     }

--- a/Quelea/src/main/java/org/quelea/windows/web/WebDrawer.java
+++ b/Quelea/src/main/java/org/quelea/windows/web/WebDrawer.java
@@ -53,12 +53,8 @@ public class WebDrawer extends DisplayableDrawer {
         webView = d.getWebView();
         webEngine = d.getWebEngine();
         if (!getCanvas().isStageView()) {
-            if (!d.getUrl().startsWith("http")) {
-                d.setUrl("http://" + d.getUrl());
-            } else {
-                if (webEngine.getTitle() == null) {
-                    webEngine.load(d.getUrl());
-                }
+            if (webEngine.getTitle() == null) {
+                webEngine.load(WebDisplayable.sanitiseUrl( d.getUrl()));
             }
             addWebView(webView);
         } else {


### PR DESCRIPTION
This updates the handling of url's in the `WebDisplayable` component to accept local file url's.

The original code just checked that the url started with "http", and appended it if not, this check
was duplicated in three locations. This check is now centralised in the `WebDisplayable` class (for
lack of an obvious better option) as `sanitiseUrl`, and then reused in all three locations.

This function parses the URL using the standard Java parser, checks that the scheme is set, and
recreates it using `http` if it does not (worth noting that this will use an unsecure connection if
not specified, which is not great, however it keeps the existing behaviour).

This also means that a badly malformed URL will throw an exception, in this case we log it and
default to `https://quelea.org/` instead. This isn't great UX, however as this can happen without
user involvement (e.g. selecting the WebDisplayable element, or loading a sequence, it seemed
preferable than any other option.



resolves #537