### PR TITLE
Update ImageGroupDisplayable getResources method to use collections #570

### DIFF
--- a/Quelea/src/main/java/org/quelea/data/displayable/ImageGroupDisplayable.java
+++ b/Quelea/src/main/java/org/quelea/data/displayable/ImageGroupDisplayable.java
@@ -139,9 +139,7 @@ public class ImageGroupDisplayable implements Displayable {
     @Override
     public Collection<File> getResources() {
         List<File> f = new ArrayList<>();
-        for (File file : files) {
-            f.add(file);
-        }
+        Collections.addAll(f, files);
         return f;
     }
 

--- a/Quelea/src/main/java/org/quelea/data/displayable/ImageGroupDisplayable.java
+++ b/Quelea/src/main/java/org/quelea/data/displayable/ImageGroupDisplayable.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;


### PR DESCRIPTION
Issue Id : #570
- Using Collection.addAll instead of loop to add each file from files