### PR TITLE
Enable custom title for ImageGroupDisplayable #558

### DIFF
--- a/Quelea/languages/gb.lang
+++ b/Quelea/languages/gb.lang
@@ -784,3 +784,5 @@ translation.text.options=Translation Text Options
 use.default.translation.label=Use Default Translation
 translation.name.label=Translation name
 ccli.licence=CCLI Licence
+dialog.image.group.header=Image Group
+dialog.image.group.title=Rename image group

--- a/Quelea/src/main/java/org/quelea/data/displayable/ImageGroupDisplayable.java
+++ b/Quelea/src/main/java/org/quelea/data/displayable/ImageGroupDisplayable.java
@@ -17,42 +17,36 @@
  */
 package org.quelea.data.displayable;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.logging.Logger;
-import javafx.scene.image.Image;
-import javafx.scene.image.ImageView;
-import org.quelea.data.imagegroup.ImageGroup;
-import org.quelea.data.imagegroup.ImageGroupFactory;
-import org.quelea.services.utils.LoggerUtils;
-import org.quelea.services.utils.QueleaProperties;
-import org.quelea.services.utils.Utils;
-import org.w3c.dom.Node;
+ import java.io.File;
+ import java.io.IOException;
+ import java.util.ArrayList;
+ import java.util.Arrays;
+ import java.util.Collection;
+ import java.util.Collections;
+ import java.util.List;
+ import java.util.Map;
+ import javafx.scene.image.Image;
+ import javafx.scene.image.ImageView;
+ import org.quelea.data.imagegroup.ImageGroup;
+ import org.quelea.data.imagegroup.ImageGroupFactory;
+ import org.quelea.services.utils.QueleaProperties;
+ import org.quelea.services.utils.Utils;
+ import org.w3c.dom.Node;
+ import org.w3c.dom.NodeList;
 
-/**
+ /**
  * A displayable that's an image group.
  * <p/>
  * @author Arvid, based on PresentationDisplayable
  */
 public class ImageGroupDisplayable implements Displayable {
-
-    private static final Logger LOGGER = LoggerUtils.getLogger();
     private final File[] files;
     private final ImageGroup presentation;
+    private final String title;
 
-    /**
-     * Create a new image group displayable
-     * <p/>
-     * @param file the file to create the PDF presentation from.
-     */
-    public ImageGroupDisplayable(File[] file) throws IOException {
+     public ImageGroupDisplayable(File[] file, String groupTitle) throws IOException {
         this.files = file;
+        this.title = groupTitle;
         presentation = new ImageGroupFactory().getPresentation(file);
         if (presentation == null) {
             throw new IOException("Error with image group, couldn't open " + Arrays.toString(file));
@@ -79,6 +73,10 @@ public class ImageGroupDisplayable implements Displayable {
     public String getXML() {
         StringBuilder ret = new StringBuilder();
         ret.append("<fileimagegroup>");
+        ret.append("<title>");
+        ret.append(Utils.escapeXML(title));
+        ret.append("</title>");
+        ret.append("<files>");
         for (File f : files) {
             String loc;
             if (QueleaProperties.get().getEmbedMediaInScheduleFile()) {
@@ -88,6 +86,7 @@ public class ImageGroupDisplayable implements Displayable {
             }
             ret.append(Utils.escapeXML(loc)).append(";");
         }
+        ret.append("</files>");
         ret.append("</fileimagegroup>");
         return ret.toString();
     }
@@ -100,15 +99,35 @@ public class ImageGroupDisplayable implements Displayable {
      * @return the object as defined by the XML.
      */
     public static ImageGroupDisplayable parseXML(Node node, Map<String, String> fileChanges) throws IOException {
-        String[] files = node.getTextContent().split(";");
-        ArrayList<File> tmp = new ArrayList<>();
-        for (String f : files) {
-            tmp.add(Utils.getChangedFile(f, fileChanges));
+        // Check for the title node. Since title is a later update, we want to maintain compatibility with older exports.
+        String title = null;
+        NodeList childNodes = node.getChildNodes();
+        if (childNodes.getLength() > 0) {
+            for (int i = 0; i < childNodes.getLength(); i++) {
+                Node childNode = childNodes.item(i);
+                if ("title".equals(childNode.getNodeName())) {
+                    title = childNode.getTextContent();
+                } else if ("files".equals(childNode.getNodeName())) {
+                    node = childNode;
+                }
+            }
         }
-        return new ImageGroupDisplayable(tmp.toArray(new File[tmp.size()]));
+        return imageGroupFromXml(node, fileChanges, title);
     }
 
-    /**
+
+     private static ImageGroupDisplayable imageGroupFromXml(Node node, Map<String, String> fileChanges, String title) throws IOException {
+         String[] files = node.getTextContent().split(";");
+         ArrayList<File> tmp = new ArrayList<>();
+         for (String f : files) {
+             tmp.add(Utils.getChangedFile(f, fileChanges));
+         }
+         File[] fileArray = tmp.toArray(new File[0]);
+         if (title == null) title = concatenatedFileNames(fileArray);
+         return new ImageGroupDisplayable(fileArray, title);
+     }
+
+     /**
      * Get the preview icon of this image group.
      * <p/>
      * @return the imagegroup preview icon.
@@ -125,11 +144,15 @@ public class ImageGroupDisplayable implements Displayable {
      */
     @Override
     public String getPreviewText() {
-        StringBuilder sb = new StringBuilder("");
+        return this.title;
+    }
+
+    public static String concatenatedFileNames(File[] files) {
+        StringBuilder sb = new StringBuilder();
         for (File f : files) {
             sb.append(f.getName()).append(", ");
         }
-        return "Image Group: " + sb.toString().substring(0, sb.toString().lastIndexOf(","));
+        return "Image Group: " + sb.substring(0, sb.toString().lastIndexOf(","));
     }
 
     /**

--- a/Quelea/src/main/java/org/quelea/windows/main/actionhandlers/AddImageActionHandler.java
+++ b/Quelea/src/main/java/org/quelea/windows/main/actionhandlers/AddImageActionHandler.java
@@ -77,14 +77,17 @@ public class AddImageActionHandler implements EventHandler<ActionEvent> {
                         try {
                             if (!halt) {
                                 Platform.runLater(() -> {
-                                    TextInputDialog dialog = new TextInputDialog();
-                                    dialog.setTitle("Rename image group");
-                                    dialog.setHeaderText("Image Group");
-                                    dialog.setGraphic(new ImageView(new Image("file:icons/image-group-schedule.png")));
-                                    Optional<String> result = dialog.showAndWait();
-                                    String imageGroupTitle;
                                     File[] filesArray = files.toArray(new File[0]);
-                                    imageGroupTitle = result.orElseGet(() -> ImageGroupDisplayable.concatenatedFileNames(filesArray));
+
+                                    TextInputDialog dialog = new TextInputDialog();
+                                    dialog.setTitle(LabelGrabber.INSTANCE.getLabel("dialog.image.group.title"));
+                                    dialog.setHeaderText(LabelGrabber.INSTANCE.getLabel("dialog.image.group.header"));
+                                    dialog.setGraphic(new ImageView(new Image("file:icons/image-group-schedule.png")));
+
+                                    String fallbackTitle = ImageGroupDisplayable.concatenatedFileNames(filesArray);
+                                    dialog.getEditor().setText(fallbackTitle);
+                                    Optional<String> result = dialog.showAndWait();
+                                    String imageGroupTitle = result.orElse(fallbackTitle);
                                     try {
                                         ImageGroupDisplayable displayable = new ImageGroupDisplayable(filesArray, imageGroupTitle);
                                         QueleaApp.get().getMainWindow().getMainPanel().getSchedulePanel().getScheduleList().add(displayable);

--- a/Quelea/src/main/java/org/quelea/windows/main/actionhandlers/AddImageActionHandler.java
+++ b/Quelea/src/main/java/org/quelea/windows/main/actionhandlers/AddImageActionHandler.java
@@ -18,14 +18,12 @@
  */
 package org.quelea.windows.main.actionhandlers;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javafx.application.Platform;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
+import javafx.scene.control.TextInputDialog;
+import javafx.scene.image.Image;
+import javafx.scene.image.ImageView;
 import javafx.stage.FileChooser;
 import org.javafx.dialog.Dialog;
 import org.quelea.data.displayable.ImageDisplayable;
@@ -36,6 +34,13 @@ import org.quelea.services.utils.LoggerUtils;
 import org.quelea.services.utils.Utils;
 import org.quelea.windows.main.QueleaApp;
 import org.quelea.windows.main.StatusPanel;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * The action handler for adding images.
@@ -72,13 +77,21 @@ public class AddImageActionHandler implements EventHandler<ActionEvent> {
                         try {
                             if (!halt) {
                                 Platform.runLater(() -> {
+                                    TextInputDialog dialog = new TextInputDialog();
+                                    dialog.setTitle("Rename image group");
+                                    dialog.setHeaderText("Image Group");
+                                    dialog.setGraphic(new ImageView(new Image("file:icons/image-group-schedule.png")));
+                                    Optional<String> result = dialog.showAndWait();
+                                    String imageGroupTitle;
+                                    File[] filesArray = files.toArray(new File[0]);
+                                    imageGroupTitle = result.orElseGet(() -> ImageGroupDisplayable.concatenatedFileNames(filesArray));
                                     try {
-                                        ImageGroupDisplayable displayable = new ImageGroupDisplayable(files.toArray(new File[files.size()]));
+                                        ImageGroupDisplayable displayable = new ImageGroupDisplayable(filesArray, imageGroupTitle);
                                         QueleaApp.get().getMainWindow().getMainPanel().getSchedulePanel().getScheduleList().add(displayable);
                                     } catch (IOException ex) {
                                         System.err.println("IO " + ex);
                                         if (!halt) {
-                                            Platform.runLater(() -> Dialog.showError(LabelGrabber.INSTANCE.getLabel("adding.presentation.error.title"), LabelGrabber.INSTANCE.getLabel("adding.presentation.error.message")));
+                                            Platform.runLater(() -> Dialog.showError(LabelGrabber.INSTANCE.getLabel("adding.presentation.error.imageGroupTitle"), LabelGrabber.INSTANCE.getLabel("adding.presentation.error.message")));
                                         }
                                     }
                                 });


### PR DESCRIPTION
Enable custom title for ImageGroupDisplayable #558

* Show a dialog after selecting and adding multiple images.
* The user can give the image group a title
* If no title is provided, the file names would be concatenated to form the image group name.
* Image group title is saved with the schedule.
* Handle backward compatibility of ImageGroup XML

The new structure of ImageGroup XML
```
<fileimagegroup>
<title>Image Group Title</title>
<files>file1;file2;</files>
</fileimagegroup>
```

* Remove unused LOGGER property

Please I will love some feedback on this implementation. Especially with regard to the dialog. Also concerning the dialog title and text, should the localization be done in a separate ticket or is it okay to do it here?
<img width="985" alt="Screenshot 2022-10-21 at 19 22 13" src="https://user-images.githubusercontent.com/11685890/197260848-abe8b9c3-0d32-40b4-8462-9592de8ac377.png">

Feedback is appreciated. Thank you

