### PR TITLE
Utils.getEncoding - treat NULL value better

### DIFF
--- a/Quelea/src/main/java/org/quelea/services/utils/Utils.java
+++ b/Quelea/src/main/java/org/quelea/services/utils/Utils.java
@@ -1143,9 +1143,11 @@ public final class Utils {
 		if (encoding == null) {
 			encoding = "UTF-8";
 			LOGGER.log(Level.WARNING, "Couldn't detect encoding, defaulting to " + encoding + " for " + file.getAbsolutePath());
-		}else{
+		}
+		else
+		{
 			LOGGER.log(Level.INFO, "Detected " + encoding + " encoding for " + file.getAbsolutePath());
-		};
+		}
 
 		return encoding;
 	}

--- a/Quelea/src/main/java/org/quelea/services/utils/Utils.java
+++ b/Quelea/src/main/java/org/quelea/services/utils/Utils.java
@@ -1133,14 +1133,20 @@ public final class Utils {
 	}
 
 	public static String getEncoding(File file) {
-		String encoding = "UTF-8";
+		String encoding;
 		try {
 			encoding = UniversalDetector.detectCharset(file);
-			LOGGER.log(Level.INFO, "Detected " + encoding + " encoding for " + file.getAbsolutePath());
 		}
 		catch (IOException ex) {
-			LOGGER.log(Level.WARNING, "Couldn't detect encoding, defaulting to " + encoding);
+			encoding = null;
 		}
+		if (encoding == null) {
+			encoding = "UTF-8";
+			LOGGER.log(Level.WARNING, "Couldn't detect encoding, defaulting to " + encoding + " for " + file.getAbsolutePath());
+		}else{
+			LOGGER.log(Level.INFO, "Detected " + encoding + " encoding for " + file.getAbsolutePath());
+		};
+
 		return encoding;
 	}
 


### PR DESCRIPTION
Though UniversalDetector.detectCharset() is in try-catch block, it doesn't always emit Exception to signal failure.
It returns NULL sometimes. This special case is treated with this commit.
It can be tested using an empty file (length 0 bytes).

Not that I hit an error with the original implementation, it is more of a safety-fix.
Was playing around EpicWorshipParser throwing an empty file at it ;-)