### PR TITLE
Fix Resource Leaks (part 1)

### DIFF
--- a/Quelea/src/main/java/org/quelea/services/importexport/EpicWorshipParser.java
+++ b/Quelea/src/main/java/org/quelea/services/importexport/EpicWorshipParser.java
@@ -44,55 +44,55 @@ public class EpicWorshipParser implements SongParser {
 
     @Override
     public List<SongDisplayable> getSongs(File location, StatusPanel statusPanel) throws IOException {
-        BufferedReader bfr = new BufferedReader(new InputStreamReader(new FileInputStream(location), Utils.getEncoding(location)));
         ArrayList<SongDisplayable> ret = new ArrayList<>();
-        String fullContents = bfr.readLine();
-        String songsWhole = fullContents.substring(10, fullContents.length() - 2);
-        String[] songInfoList = songsWhole.split("\\},\\{");
-        for (String songInfo : songInfoList) {
-            songInfo = songInfo.replace("{", "").replace("{", "");
-            Matcher m1 = NAME.matcher(songInfo);
-            String name = "";
-            String author = "";
-            String lyrics = "";
-            if (m1.find()) {
-                name = m1.group(0);
-                name = format(name);
-            }
-
-            Matcher m2 = AUTHOR.matcher(songInfo);
-            if (m2.find()) {
-                author = m2.group(0);
-                author = format(author);
-            }
-
-            Matcher m3 = LYRICS.matcher(songInfo);
-            if (m3.find()) {
-                lyrics = m3.group(0);
-                lyrics = format(lyrics);
-            }
-
-            SongDisplayable s = new SongDisplayable(name, author);
-
-            ArrayList<String> section = new ArrayList<>();
-            int sectionCount = 0;
-            String[] lines = lyrics.split("\\\\n");
-            for (String line : lines) {
-                if (!line.isEmpty()) {
-                    section.add(line);
-                } else {
-                    String[] sectionsArray = new String[section.size()];
-                    s.addSection(sectionCount, new TextSection("", section.toArray(sectionsArray), section.toArray(sectionsArray), true));
-                    sectionCount++;
-                    section.clear();
+        try (BufferedReader bfr = new BufferedReader(new InputStreamReader(new FileInputStream(location), Utils.getEncoding(location)))){
+            String fullContents = bfr.readLine();
+            String songsWhole = fullContents.substring(10, fullContents.length() - 2);
+            String[] songInfoList = songsWhole.split("\\},\\{");
+            for (String songInfo : songInfoList) {
+                songInfo = songInfo.replace("{", "").replace("{", "");
+                Matcher m1 = NAME.matcher(songInfo);
+                String name = "";
+                String author = "";
+                String lyrics = "";
+                if (m1.find()) {
+                    name = m1.group(0);
+                    name = format(name);
                 }
-            }
-            String[] sectionsArray = new String[section.size()];
-            s.addSection(sectionCount, new TextSection("", section.toArray(sectionsArray), section.toArray(sectionsArray), true));
 
-            ret.add(s);
+                Matcher m2 = AUTHOR.matcher(songInfo);
+                if (m2.find()) {
+                    author = m2.group(0);
+                    author = format(author);
+                }
+
+                Matcher m3 = LYRICS.matcher(songInfo);
+                if (m3.find()) {
+                    lyrics = m3.group(0);
+                    lyrics = format(lyrics);
+                }
+
+                SongDisplayable s = new SongDisplayable(name, author);
+
+                ArrayList<String> section = new ArrayList<>();
+                int sectionCount = 0;
+                String[] lines = lyrics.split("\\\\n");
+                for (String line : lines) {
+                    if (!line.isEmpty()) {
+                        section.add(line);
+                    } else {
+                        String[] sectionsArray = new String[section.size()];
+                        s.addSection(sectionCount, new TextSection("", section.toArray(sectionsArray), section.toArray(sectionsArray), true));
+                        sectionCount++;
+                        section.clear();
+                    }
+                }
+                String[] sectionsArray = new String[section.size()];
+                s.addSection(sectionCount, new TextSection("", section.toArray(sectionsArray), section.toArray(sectionsArray), true));
+
+                ret.add(s);
+            }
         }
-        bfr.close();
         return ret;
     }
 

--- a/Quelea/src/main/java/org/quelea/services/importexport/EpicWorshipParser.java
+++ b/Quelea/src/main/java/org/quelea/services/importexport/EpicWorshipParser.java
@@ -92,6 +92,7 @@ public class EpicWorshipParser implements SongParser {
 
             ret.add(s);
         }
+        bfr.close();
         return ret;
     }
 

--- a/Quelea/src/main/java/org/quelea/services/importexport/SongBeamerParser.java
+++ b/Quelea/src/main/java/org/quelea/services/importexport/SongBeamerParser.java
@@ -55,14 +55,15 @@ public class SongBeamerParser implements SongParser {
     @Override
     public List<SongDisplayable> getSongs(File file, StatusPanel statusPanel) throws IOException {
         List<SongDisplayable> ret = new ArrayList<>();
-        BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), Charset.forName("Cp1250")));
-        String fileLine;
-        StringBuilder rawLinesBuilder = new StringBuilder();
-        while ((fileLine = reader.readLine()) != null) {
-            rawLinesBuilder.append(fileLine).append("\n");
+        String rawLines;
+        try(BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), Charset.forName("Cp1250")))){
+            String fileLine;
+            StringBuilder rawLinesBuilder = new StringBuilder();
+            while ((fileLine = reader.readLine()) != null) {
+                rawLinesBuilder.append(fileLine).append("\n");
+            }
+            rawLines = rawLinesBuilder.toString();
         }
-        String rawLines = rawLinesBuilder.toString();
-        reader.close();
 
         Map<String, String> songProps = new HashMap<>();
         for (String line : rawLines.split("\n")) {

--- a/Quelea/src/main/java/org/quelea/services/importexport/SongBeamerParser.java
+++ b/Quelea/src/main/java/org/quelea/services/importexport/SongBeamerParser.java
@@ -62,6 +62,7 @@ public class SongBeamerParser implements SongParser {
             rawLinesBuilder.append(fileLine).append("\n");
         }
         String rawLines = rawLinesBuilder.toString();
+        reader.close();
 
         Map<String, String> songProps = new HashMap<>();
         for (String line : rawLines.split("\n")) {


### PR DESCRIPTION
In EpicWorshipParser and SongBeamerParser the input files were opened and never closed.
Not a big bug as these import functions are rarely used. Files were closed at Quelea's termination.
Fixed anyway with this PR.