### PR TITLE
#542 included other items in printed schedule

### DIFF
--- a/Quelea/scheduleformat.xsl
+++ b/Quelea/scheduleformat.xsl
@@ -2,6 +2,7 @@
 <xsl:stylesheet version="1.1" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format" xmlns:xslt="http://www.w3.org/1999/XSL/Transform"
                 exclude-result-prefixes="fo">
+    <xsl:template match="*"></xsl:template>
     <xsl:template match="schedule">
         <fo:root xmlns:fo="http://www.w3.org/1999/XSL/Format" font-family="Roboto">
             <fo:layout-master-set>
@@ -14,34 +15,109 @@
                     <fo:block font-size="18pt" font-weight="bold" space-after="12pt">
                         <xsl:value-of select="title"/>
                     </fo:block>
-                    <xsl:apply-templates select="song|passage"/>
+                    <xsl:apply-templates select="*"/>
                 </fo:flow>
             </fo:page-sequence>
         </fo:root>
     </xsl:template>
-    <xsl:template match="song">
-        <fo:block space-after="10pt">
-            <xsl:value-of select="position()"/>.
-            <xsl:value-of select="title"/>
-            <xsl:choose>
-                <xsl:when test="author != ''">
-                    - <xsl:value-of select="author"/>
-                </xsl:when>
-            </xsl:choose>
-            <xsl:choose>
-                <xsl:when test="ccli != ''">
-                    (CCLI <xsl:value-of select="ccli"/>)
-                </xsl:when>
-            </xsl:choose>
+    <xsl:template name="row">
+        <xsl:param name = "content" />
+        <xsl:param name = "details" />
+        <fo:block space-after="24pt">
+            <xsl:value-of select="position() -1"/>.
+            <fo:inline font-size="12pt" padding-left="4mm" >
+            <xsl:value-of select = "$content" />
+            </fo:inline>
+            <fo:inline font-size="8pt" padding-left="22mm" font-style="italic">
+                <xsl:value-of select = "$details" />
+            </fo:inline>
         </fo:block>
     </xsl:template>
+    <xsl:template match="song">
+        <xsl:call-template name="row">
+            <xsl:with-param name="content">
+                <xsl:value-of select="title"/>
+            </xsl:with-param>
+            <xsl:with-param name="details">
+                <xsl:choose>
+                    <xsl:when test="author != ''"><xsl:value-of select="author"/></xsl:when>
+                </xsl:choose>
+                <xsl:choose>
+                    <xsl:when test="ccli != ''">(CCLI <xsl:value-of select="ccli"/>)</xsl:when>
+                </xsl:choose>
+            </xsl:with-param>
+        </xsl:call-template>
+    </xsl:template>
     <xsl:template match="passage">
-        <fo:block space-after="10pt">
-            <xsl:value-of select="position()"/>.
-            <xsl:value-of select="@summary"/>
-            <xsl:when test="@bible != ''">
-                (<xsl:value-of select="@bible"/>)
-            </xsl:when>
-        </fo:block>
+        <xsl:call-template name="row">
+            <xsl:with-param name="content">
+                <xsl:value-of select="@summary"/>
+            </xsl:with-param>
+            <xsl:with-param name="details">
+                <xsl:choose>
+                    <xsl:when test="@bible != ''">(<xsl:value-of select="@bible"/>) </xsl:when>
+                </xsl:choose>
+            </xsl:with-param>
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template name="file">
+        <xsl:param name = "filetype" />
+        <xsl:call-template name="row">
+            <xsl:with-param name="content">
+                <xsl:value-of select="$filetype"/>
+            </xsl:with-param>
+            <xsl:with-param name="details">
+                <fo:inline font-family="monospace"><xsl:value-of select="text()"/></fo:inline>
+            </xsl:with-param>
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="fileaudio">
+        <xsl:call-template name="file">
+            <xsl:with-param name="filetype">
+                Audio
+            </xsl:with-param>
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="fileimage">
+        <xsl:call-template name="file">
+            <xsl:with-param name="filetype">
+                Image
+            </xsl:with-param>
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="filepdf">
+        <xsl:call-template name="file">
+            <xsl:with-param name="filetype">
+                PDF
+            </xsl:with-param>
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="filepresentation">
+        <xsl:call-template name="file">
+            <xsl:with-param name="filetype">
+                Presentation
+            </xsl:with-param>
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="filevideo">
+        <xsl:call-template name="file">
+            <xsl:with-param name="filetype">
+                Video
+            </xsl:with-param>
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="url">
+        <xsl:call-template name="file">
+            <xsl:with-param name="filetype">
+                Web
+            </xsl:with-param>
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="fileimagegroup">
+        <xsl:call-template name="file">
+            <xsl:with-param name="filetype">
+                Image Group
+            </xsl:with-param>
+        </xsl:call-template>
     </xsl:template>
 </xsl:stylesheet>

--- a/Quelea/scheduleformat.xsl
+++ b/Quelea/scheduleformat.xsl
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
-<xsl:stylesheet version="1.1" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:fo="http://www.w3.org/1999/XSL/Format" exclude-result-prefixes="fo">
+<xsl:stylesheet version="1.1" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:fo="http://www.w3.org/1999/XSL/Format" xmlns:xslt="http://www.w3.org/1999/XSL/Transform"
+                exclude-result-prefixes="fo">
     <xsl:template match="schedule">
         <fo:root xmlns:fo="http://www.w3.org/1999/XSL/Format" font-family="Roboto">
             <fo:layout-master-set>
@@ -12,24 +14,34 @@
                     <fo:block font-size="18pt" font-weight="bold" space-after="12pt">
                         <xsl:value-of select="title"/>
                     </fo:block>
-                    <xsl:for-each select="song">
-                        <fo:block space-after="10pt">
-                            <xsl:value-of select="position()"/>.
-                            <xsl:value-of select="title"/>
-                            <xsl:choose>
-                                <xsl:when test="author != ''">
-                                    - <xsl:value-of select="author"/> 
-                                </xsl:when>
-                            </xsl:choose>
-                            <xsl:choose>
-                                <xsl:when test="ccli != ''">
-                                    (CCLI <xsl:value-of select="ccli"/>)
-                                </xsl:when>
-                            </xsl:choose>
-                        </fo:block>
-                    </xsl:for-each>
+                    <xsl:apply-templates select="song|passage"/>
                 </fo:flow>
             </fo:page-sequence>
         </fo:root>
+    </xsl:template>
+    <xsl:template match="song">
+        <fo:block space-after="10pt">
+            <xsl:value-of select="position()"/>.
+            <xsl:value-of select="title"/>
+            <xsl:choose>
+                <xsl:when test="author != ''">
+                    - <xsl:value-of select="author"/>
+                </xsl:when>
+            </xsl:choose>
+            <xsl:choose>
+                <xsl:when test="ccli != ''">
+                    (CCLI <xsl:value-of select="ccli"/>)
+                </xsl:when>
+            </xsl:choose>
+        </fo:block>
+    </xsl:template>
+    <xsl:template match="passage">
+        <fo:block space-after="10pt">
+            <xsl:value-of select="position()"/>.
+            <xsl:value-of select="@summary"/>
+            <xsl:when test="@bible != ''">
+                (<xsl:value-of select="@bible"/>)
+            </xsl:when>
+        </fo:block>
     </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
As reported in issue #542 , currently only songs are included in the printed schedule pdf.

This change extends the `scheduleformat.xsl` to support more types (AFAIK it now covers all valid types).

To reduce code duplication it creates a new template named `row` which accepts a `content` and `details` parameter, which keeps the specific formatting all in one location in the file. There are many `file*` types which are also templated to reduce code duplication.