### PR TITLE
Speeding up Grade application>run task

### DIFF
--- a/Quelea/build.gradle
+++ b/Quelea/build.gradle
@@ -25,6 +25,9 @@ repositories {
     mavenCentral()
     maven {
         url 'https://oss.sonatype.org/content/repositories/snapshots/'
+        content {
+            includeGroup 'org.quelea'
+        }
         mavenContent {
             snapshotsOnly()
         }


### PR DESCRIPTION
build.gradle file has a reference to sonatype snapshots repo, this causes dependencyUpdates stage to be slow and checkout snapshot poms for a number of dependencies.

Adding filter for org.quelea only as it seems to be used for pulling in a snapshot for planning-center.