### PR TITLE
Bible book name caption

### DIFF
--- a/Quelea/src/main/java/org/quelea/data/bible/BibleBook.java
+++ b/Quelea/src/main/java/org/quelea/data/bible/BibleBook.java
@@ -182,7 +182,7 @@ public final class BibleBook implements BibleInterface, Serializable {
                 if ret.bookName == "" && i == 0 {
                     Node caption = list.item(i).getFirstChild();
                     if (caption != null && caption.getNodeName().equalsIgnoreCase("caption")) {
-                        ret.bookNumber = caption.getNodeValue()
+                        ret.bookName = caption.getNodeValue()
                     }
                 }
             }

--- a/Quelea/src/main/java/org/quelea/data/bible/BibleBook.java
+++ b/Quelea/src/main/java/org/quelea/data/bible/BibleBook.java
@@ -168,7 +168,7 @@ public final class BibleBook implements BibleInterface, Serializable {
         } else if (node.getAttributes().getNamedItem("osisID") != null) {
             ret.bookName = node.getAttributes().getNamedItem("osisID").getNodeValue();
         } else {
-            ret.bookName = defaultBookName;
+            ret.bookName = "";
         }
         
         if (node.getAttributes().getNamedItem("bsname") != null) {
@@ -183,8 +183,20 @@ public final class BibleBook implements BibleInterface, Serializable {
                 BibleChapter chapter = BibleChapter.parseXML(list.item(i), i);
                 chapter.setBook(ret);
                 ret.addChapter(chapter);
+
+                if ret.bookName == "" && i == 0 {
+                    Node caption = list.item(i).getFirstChild();
+                    if (caption != null && caption.getNodeName().equalsIgnoreCase("caption")) {
+                        ret.bookNumber = caption.getTextContent()
+                    }
+                }
             }
         }
+
+        if ret.bookName == "" {
+            ret.bookName = defaultBookName;
+        }
+
         LOGGER.log(Level.INFO, "Parsed " + ret.getChapters().length + " chapters in " + ret.bookName);
         return ret;
     }

--- a/Quelea/src/main/java/org/quelea/data/bible/BibleBook.java
+++ b/Quelea/src/main/java/org/quelea/data/bible/BibleBook.java
@@ -170,12 +170,7 @@ public final class BibleBook implements BibleInterface, Serializable {
         } else {
             ret.bookName = "";
         }
-        
-        if (node.getAttributes().getNamedItem("bsname") != null) {
-            ret.bsname = node.getAttributes().getNamedItem("bsname").getNodeValue();
-        } else {
-            ret.bsname = ret.bookName;
-        }
+
         NodeList list = node.getChildNodes();
         for (int i = 0; i < list.getLength(); i++) {
             if (list.item(i).getNodeName().equalsIgnoreCase("chapter")
@@ -187,7 +182,7 @@ public final class BibleBook implements BibleInterface, Serializable {
                 if ret.bookName == "" && i == 0 {
                     Node caption = list.item(i).getFirstChild();
                     if (caption != null && caption.getNodeName().equalsIgnoreCase("caption")) {
-                        ret.bookNumber = caption.getTextContent()
+                        ret.bookNumber = caption.getNodeValue()
                     }
                 }
             }
@@ -195,6 +190,12 @@ public final class BibleBook implements BibleInterface, Serializable {
 
         if ret.bookName == "" {
             ret.bookName = defaultBookName;
+        }
+
+        if (node.getAttributes().getNamedItem("bsname") != null) {
+            ret.bsname = node.getAttributes().getNamedItem("bsname").getNodeValue();
+        } else {
+            ret.bsname = ret.bookName;
         }
 
         LOGGER.log(Level.INFO, "Parsed " + ret.getChapters().length + " chapters in " + ret.bookName);

--- a/Quelea/src/main/java/org/quelea/data/bible/BibleBook.java
+++ b/Quelea/src/main/java/org/quelea/data/bible/BibleBook.java
@@ -179,16 +179,16 @@ public final class BibleBook implements BibleInterface, Serializable {
                 chapter.setBook(ret);
                 ret.addChapter(chapter);
 
-                if ret.bookName == "" && i == 0 {
+                if (ret.bookName == "" && i == 0) {
                     Node caption = list.item(i).getFirstChild();
                     if (caption != null && caption.getNodeName().equalsIgnoreCase("caption")) {
-                        ret.bookName = caption.getNodeValue()
+                        ret.bookName = caption.getNodeValue();
                     }
                 }
             }
         }
 
-        if ret.bookName == "" {
+        if (ret.bookName == "") {
             ret.bookName = defaultBookName;
         }
 


### PR DESCRIPTION
In Zefania XML Bile in Russian ([RST](https://sourceforge.net/projects/zefania-sharp/files/Bibles/RUS/Russian%20Synodal%20Translation/)), the Bible book names are presented in the <CAPTION> node inside the first chapter of each book. Added the parsing condition to handle this case.

Still cannot build the project on my M1, hope this is working.