### PR TITLE
Change bundled JDKs into JREs

### DIFF
--- a/Quelea/build.gradle
+++ b/Quelea/build.gradle
@@ -102,12 +102,12 @@ task downloadGStreamer {
 task downloadJres {
     def mf = new File('macjre.zip')
     if (!mf.exists()) {
-        new URL('https://cdn.azul.com/zulu/bin/zulu21.32.17-ca-fx-jdk21.0.2-macosx_x64.zip').withInputStream{ i -> mf.withOutputStream{ it << i }}
+        new URL('https://cdn.azul.com/zulu/bin/zulu21.40.17-ca-fx-jre21.0.6-macosx_x64.zip').withInputStream{ i -> mf.withOutputStream{ it << i }}
     }
 
     def wf = new File('winjre64.zip')
     if (!wf.exists()) {
-        new URL('https://cdn.azul.com/zulu/bin/zulu21.32.17-ca-fx-jdk21.0.2-win_x64.zip').withInputStream{ i -> wf.withOutputStream{ it << i }}
+        new URL('https://cdn.azul.com/zulu/bin/zulu21.40.17-ca-fx-jre21.0.6-win_x64.zip').withInputStream{ i -> wf.withOutputStream{ it << i }}
     }
 
     doLast {
@@ -134,7 +134,7 @@ task copyToDist {
         copy {from "timer" into project.distdir + "/timer"}
         copy {from "src" into project.distdir + "/src"}
         copy {from zipTree("bundlejre/winjre64.zip") into project.distdir}
-        file("dist/zulu21.32.17-ca-fx-jdk21.0.2-win_x64").renameTo(file("dist/winjre64"))
+        file("dist/zulu21.40.17-ca-fx-jre21.0.6-win_x64").renameTo(file("dist/winjre64"))
         copy {from file("build/libs/Quelea.jar") into file(project.distdir)}
         copy {from file("README.TXT") into file(project.distdir)}
         copy {from file("quelea.properties") into file(project.distdir)}


### PR DESCRIPTION
The clients only need to execute, so I guess just a JRE would suffice. Changed the JDKs into JRE's (still with the FX libs included and by Azul) which should result in reduced standalone sizes.