### PR TITLE
Reduce `lib/` sizes for standalone Windows and MacOS installers

### DIFF
--- a/Quelea/build.gradle
+++ b/Quelea/build.gradle
@@ -120,7 +120,8 @@ task downloadJres {
 
 task copyToDist {
     doLast {
-        copy {from configurations.runtimeClasspath into project.distdir + "/lib"} //libraries
+        copy {from configurations.runtimeClasspath into project.distdir + "/libjfx" include "javafx*" } // all JavaFX libraries
+        copy {from configurations.runtimeClasspath into project.distdir + "/lib" exclude "javafx*" } // all libraries except JavaFX libraries
         copy {from "themes" into project.distdir + "/themes"}
         copy {from "icons" into project.distdir + "/icons"}
         copy {from "bibles" into project.distdir + "/bibles"}

--- a/Quelea/izpack/config.xml
+++ b/Quelea/izpack/config.xml
@@ -68,6 +68,7 @@
         <pack name="base" required="yes" preselected="yes" hidden="true">
             <description>Core components</description>
             <fileset dir="lib" targetdir="$INSTALL_PATH/lib"/>
+            <fileset dir="libjfx" targetdir="$INSTALL_PATH/lib"/>
             <file src="vbs" targetdir="$INSTALL_PATH"/>
             <file src="Quelea.jar" targetdir="$INSTALL_PATH"/>
             <file src="Quelea.bat" targetdir="$INSTALL_PATH"/>


### PR DESCRIPTION
The `lib/` contained JavaFX libraries/jars, while the standalone installers already come with a JDK package that includes JavaFX. This means all the JavaFX libraries are duplicated for Windows and MacOS.

I excluded `javafx*` from the `libs/`. For the IzPack/cross-platform installer, Gradle build will create a `libjfx` folder with only the JavaFX libraries included for IzPack, because IzPack will use the same target dir `lib/` for both libraries from `dist/lib/` and `dist/libjfx/`. This should result in reduced standalone sizes for Windows and MacOS.

Tested IzPack on Linux. P.S. I believe there are some flags missing in the IzPack/SortcutSpecs that are needed since JDK >= 9 or 11 (those `--add-opens`).
