### PR TITLE
GH Action: PR build/check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,7 @@ on:
 
 jobs:
   release:
-    strategy:
-      matrix:
-        os: [windows-2025, ubuntu-24.04]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -26,29 +23,35 @@ jobs:
       
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-
-      - name: Windows innosetup
-        if: ${{ contains(matrix.os, 'windows') }}
+      
+      - name: Setup Wine
         run: |
-          Invoke-WebRequest -Uri  http://files.jrsoftware.org/is/6/innosetup-6.2.2.exe -OutFile is.exe
-          .\is.exe /VERYSILENT /SUPPRESSMSGBOXES
+          sudo dpkg --add-architecture i386
+          sudo apt update
+          sudo apt install wine wine32 wine64
+
+      - name: Setup Inno Setup cache
+        id: cache-innosetup
+        uses: actions/cache@v4
+        with:
+          path: ~/.wine/drive_c/Program Files (x86)/Inno Setup 6
+          key: ${{ runner.os }}-innosetup
+
+      - name: Install InnoSetup
+        if: ${{ ! steps.cache-innosetup.outputs.cache-hit }} # || true on Inno Setup update
+        env:
+          DISPLAY: :99
+          WINEDEBUG: -all,err+all
+          WINEARCH: win64
+        run: |
+          Xvfb $DISPLAY &
+          curl -SL "https://files.jrsoftware.org/is/6/innosetup-6.2.2.exe" -o is.exe
+          wine is.exe /SP- /VERYSILENT /ALLUSERS /SUPPRESSMSGBOXES
 
       - name: Build
         run: |
           cd Quelea
-          gradle -Dnightly=true -Dversionsuffix=CI-UNSTABLE clean labelcheck downloadJres jar copyToDist
-
-      - name: Create MacOS standalone and CP-installer
-        if: ${{ !contains(matrix.os, 'windows') }}
-        run: |
-          cd Quelea
-          gradle -Dnightly=true -Dversionsuffix=CI-UNSTABLE runPackr izpack releaseSummary
-
-      - name: Create Windows standalone
-        if: ${{ contains(matrix.os, 'windows') }}
-        run: |
-          cd Quelea
-          gradle -Dnightly=true -Dversionsuffix=CI-UNSTABLE downloadGStreamer createQueleaExe64 innosetup releaseSummary
+          gradle -Dnightly=true -Dversionsuffix=CI-UNSTABLE clean dist
 
       - name: Upload binaries to release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,13 @@ name: Build CI release
 on:
   push:
     branches:
-      - 'master'
+      - master
     # paths:
     #   - 'Quelea/**'
+
+  pull_request:
+    branches:
+      - master
 
 jobs:
   release:
@@ -54,6 +58,7 @@ jobs:
           gradle -Dnightly=true -Dversionsuffix=CI-UNSTABLE clean dist
 
       - name: Upload binaries to release
+        if: ${{ github.event_name == 'push' }}
         uses: softprops/action-gh-release@v2
         with:
           files: Quelea/dist/standalone/*
@@ -65,3 +70,9 @@ jobs:
                 Quelea is also distributed as a Linux snap package. To install it, make 
                 sure snap is installed then run:
                 <pre>sudo snap install --edge quelea</pre>"
+
+      - name: Upload standalones as artifact of PR
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@v4
+        with:
+          path: Quelea/dist/standalone/


### PR DESCRIPTION
Uses PR #677 as base

This PR adds a trigger to the build.yml Github Action to also execute the Build Action on PRs opened to Quelea. It will however skip the publish release step (it won't publish PRs as a release), but it will upload the standalones created by the build as an artifact, which can be found by going to the "Build CI release / release (pull_request) -> View Details -> Summary -> scroll down to the "Artifacts" section. 

The artifact contains the standalone installers, so that you can test the standalone installers produced by the PR without having to build it manually yourself. It also serves as a check so that you know the PR works and builds without issues. If the build fails, it'll immediately let the PR submitter know so they can fix it. 

![image](https://github.com/user-attachments/assets/d30f1474-6844-4686-ba0d-269a639b4bac)
