### PR TITLE
Change GH Action JDK+FX Zulu to just the Temurin JDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,8 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '21'
-          java-package: 'jdk+fx'
-          distribution: 'zulu'
+          java-package: 'jdk'
+          distribution: 'temurin'
       
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4


### PR DESCRIPTION
The Temurin JDK comes preinstalled on the Github-hosted Runners so it saves some time from installing. The FX libraries aren't used for building, but are rather only needed for the runtime, which is still taken care of because the runtimes are installed by the the standalone installers that still come with the bundled JRE+FX (Zulu) from Azul. 

(The libraries required during compilation/building with Gradle are provided by the Gradle, by the JavaFX plugin and the dependencies from build.gradle and don't need to come bundled with the JDK; only for buildtime/compile, only runtime needs and still gets that JDK+FX bundle)