### PR TITLE
Change download location InnoSetup in GitHub workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
           WINEARCH: win64
         run: |
           Xvfb $DISPLAY &
-          curl -SL "https://files.jrsoftware.org/is/6/innosetup-6.2.2.exe" -o is.exe
+          curl -SL "https://github.com/jrsoftware/issrc/releases/download/is-6_2_1/innosetup-6.2.1.exe" -o is.exe
           wine is.exe /SP- /VERYSILENT /ALLUSERS /SUPPRESSMSGBOXES
 
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
           WINEARCH: win64
         run: |
           Xvfb $DISPLAY &
-          curl -SL "https://github.com/jrsoftware/issrc/releases/download/is-6_2_1/innosetup-6.2.1.exe" -o is.exe
+          curl -SL "https://github.com/jrsoftware/issrc/releases/download/is-6_2_2/innosetup-6.2.2.exe" -o is.exe
           wine is.exe /SP- /VERYSILENT /ALLUSERS /SUPPRESSMSGBOXES
 
       - name: Build


### PR DESCRIPTION
It seems InnoSetup has changed their download URL from https://files.jrsoftware.org/is/6/innosetup-6.2.2.exe to their GitHub (see their download page: https://jrsoftware.org/isdl.php). This now causes the build to fail when it tries to pull InnoSetup, but is fixed by changing the download link to InnoSetups GitHub repository.