### PR TITLE
Fix PPT running in background start presentation when Live is not a PPT & loop button is pressed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
           WINEARCH: win64
         run: |
           Xvfb $DISPLAY &
-          curl -SL "https://files.jrsoftware.org/is/6/innosetup-6.2.2.exe" -o is.exe
+          curl -SL "https://github.com/jrsoftware/issrc/releases/download/is-6_2_1/innosetup-6.2.1.exe" -o is.exe
           wine is.exe /SP- /VERYSILENT /ALLUSERS /SUPPRESSMSGBOXES
 
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
           WINEARCH: win64
         run: |
           Xvfb $DISPLAY &
-          curl -SL "https://github.com/jrsoftware/issrc/releases/download/is-6_2_1/innosetup-6.2.1.exe" -o is.exe
+          curl -SL "https://github.com/jrsoftware/issrc/releases/download/is-6_2_2/innosetup-6.2.2.exe" -o is.exe
           wine is.exe /SP- /VERYSILENT /ALLUSERS /SUPPRESSMSGBOXES
 
       - name: Build

--- a/Quelea/src/main/java/org/quelea/windows/main/LivePanel.java
+++ b/Quelea/src/main/java/org/quelea/windows/main/LivePanel.java
@@ -107,7 +107,9 @@ public class LivePanel extends LivePreviewPanel {
         loop = new ToggleButton(LabelGrabber.INSTANCE.getLabel("loop.label") + ":");
         loop.setOnMouseClicked(e -> {
             if (isLoopSelected()) {
-                PowerPointHandler.loopPresentation();
+                if (getDisplayable() instanceof PresentationDisplayable) {
+                    PowerPointHandler.loopPresentation();
+                }
             } else {
                 PowerPointHandler.stopLoop();
             }


### PR DESCRIPTION
Fixes #701 & includes #704 (assumes #704 will be merged)

> Our church exports PowerPoints to PDFs, which are then added to the order of schedule of Quelea. It sometimes occurs that we still have the PowerPoint window open to make adjustments, but when the loop button is pressed when a PDF is Live the PowerPoint window also seems to start a slideshow on top of Quelea's Projection Window.