### PR TITLE
Fix Gradle Run task

### DIFF
--- a/Quelea/build.gradle
+++ b/Quelea/build.gradle
@@ -8,7 +8,6 @@ buildscript {
 
 plugins {
     id 'application'
-    id 'java'
     id 'org.openjfx.javafxplugin' version '0.1.0'
     id 'edu.sc.seis.launch4j' version '4.0.0'
     id 'com.github.ben-manes.versions' version '0.53.0'
@@ -75,6 +74,11 @@ compileJava.finalizedBy(dependencyUpdates)
 
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 ext.mainClass = 'org.quelea.windows.main.MainStub'
+
+application {
+    mainClass = 'org.quelea.windows.main.MainStub'
+    applicationDefaultJvmArgs = ["--add-opens=java.base/java.nio=ALL-UNNAMED", "-Dglass.accessible.force=false", "--add-exports=javafx.graphics/com.sun.javafx.css=ALL-UNNAMED", "--add-exports=javafx.base/com.sun.javafx.runtime=ALL-UNNAMED", "--add-exports=javafx.base/com.sun.javafx.event=ALL-UNNAMED", "--add-opens=java.base/java.lang=ALL-UNNAMED", "--add-opens=javafx.controls/javafx.scene.control=ALL-UNNAMED"]
+}
 
 tasks.register('createQueleaExe64', edu.sc.seis.launch4j.tasks.Launch4jLibraryTask) { //Launch4j
     mainClassName = 'org.quelea.windows.main.MainStub'


### PR DESCRIPTION
Removed the Java Gradle plugin, because:

> Applying the Application plugin also implicitly applies the [Java plugin](https://docs.gradle.org/current/userguide/java_plugin.html#java_plugin). The main source set is effectively the "application".

Source: https://docs.gradle.org/current/userguide/application_plugin.html


Also set the application configuration so that `gradle run` starts Quelea, which it does not do at the moment on a fresh clone.