### PR TITLE
Fix PPT in background start presentation and loop when loop btn clicked

### DIFF
--- a/Quelea/src/main/java/org/quelea/windows/main/LivePanel.java
+++ b/Quelea/src/main/java/org/quelea/windows/main/LivePanel.java
@@ -106,10 +106,12 @@ public class LivePanel extends LivePreviewPanel {
         header.getItems().add(liveIcon);
         loop = new ToggleButton(LabelGrabber.INSTANCE.getLabel("loop.label") + ":");
         loop.setOnMouseClicked(e -> {
-            if (isLoopSelected()) {
-                PowerPointHandler.loopPresentation();
-            } else {
-                PowerPointHandler.stopLoop();
+            if (getDisplayable() instanceof PresentationDisplayable) {
+                if (isLoopSelected()) {
+                    PowerPointHandler.loopPresentation();
+                } else {
+                    PowerPointHandler.stopLoop();
+                }
             }
         });
         loopDuration = new TextField("10");


### PR DESCRIPTION
Pressing the loop button would always cause a PowerPoint window open in the background to start the presentation without it being what is projected Live (even if turning off the loop button), and start/stop looping (depending on state of the button). This fix includes a check to see whether Live is actually displaying a presentation.